### PR TITLE
Fix panic in handler.validateReturns()

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -58,7 +58,7 @@ func validateReturns(handler reflect.Type) error {
 		if !handler.Out(1).Implements(errorType) {
 			return fmt.Errorf("handler returns two values, but the second does not implement error")
 		}
-	} else {
+	} else if handler.NumOut() == 1 {
 		if !handler.Out(0).Implements(errorType) {
 			return fmt.Errorf("handler returns a single value, but it does not implement error")
 		}

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -63,12 +63,17 @@ func TestInvalidHandlers(t *testing.T) {
 				return "hello"
 			},
 		},
+		{
+			name:     "no return value should not result in error",
+			expected: nil,
+			handler: func() {
+			},
+		},
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
 			lambdaHandler := newHandler(testCase.handler)
 			_, err := lambdaHandler.Invoke(context.TODO(), make([]byte, 0))
-			assert.NotNil(t, err)
 			assert.Equal(t, testCase.expected, err)
 		})
 	}


### PR DESCRIPTION
This fixes a panic when invoking validateReturns() on a function without returns. Fixes #3