### PR TITLE
Adds custom authorizer context to APIGW Request

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -33,6 +33,7 @@ type APIGatewayProxyRequestContext struct {
 	RequestID    string                    `json:"requestId"`
 	Identity     APIGatewayRequestIdentity `json:"identity"`
 	ResourcePath string                    `json:"resourcePath"`
+	Authorizer   map[string]interface{}    `json:"authorizer"`
 	HTTPMethod   string                    `json:"httpMethod"`
 	APIID        string                    `json:"apiId"` // The API Gateway rest API Id
 }
@@ -53,6 +54,7 @@ type APIGatewayRequestIdentity struct {
 }
 
 // APIGatewayCustomAuthorizerContext represents the expected format of an API Gateway custom authorizer response.
+// Deprecated. Code should be updated to use the Authorizer map from APIGatewayRequestIdentity. Ex: Authorizer["principalId"]
 type APIGatewayCustomAuthorizerContext struct {
 	PrincipalID *string `json:"principalId"`
 	StringKey   *string `json:"stringKey,omitempty"`

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -24,6 +24,14 @@ func TestApiGatewayRequestMarshaling(t *testing.T) {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
+	// validate custom authorizer context
+	authContext := inputEvent.RequestContext.Authorizer
+	if authContext["principalId"] != "admin" ||
+		authContext["clientId"] != 1.0 ||
+		authContext["clientName"] != "Exata" {
+		t.Errorf("could not extract authorizer context: %v", authContext)
+	}
+
 	// serialize to json
 	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -1,59 +1,63 @@
-	{ 
-		"resource": "/{proxy+}",
-	  	"path": "/hello/world",
-	  	"httpMethod": "POST",
-	  	"headers": {
-			  "Accept": "*/*",
-			  "Accept-Encoding": "gzip, deflate",
-			  "cache-control": "no-cache",
-			  "CloudFront-Forwarded-Proto": "https",
-			  "CloudFront-Is-Desktop-Viewer": "true",
-			  "CloudFront-Is-Mobile-Viewer": "false",
-			  "CloudFront-Is-SmartTV-Viewer": "false",
-			  "CloudFront-Is-Tablet-Viewer": "false",
-			  "CloudFront-Viewer-Country": "US",
-			  "Content-Type": "application/json",
-			  "headerName": "headerValue",
-			  "Host": "gy415nuibc.execute-api.us-east-1.amazonaws.com",
-			  "Postman-Token": "9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f",
-			  "User-Agent": "PostmanRuntime/2.4.5",
-			  "Via": "1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)",
-			  "X-Amz-Cf-Id": "pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==",
-			  "X-Forwarded-For": "54.240.196.186, 54.182.214.83",
-			  "X-Forwarded-Port": "443",
-			  "X-Forwarded-Proto": "https"
+{ 
+	"resource": "/{proxy+}",
+	  "path": "/hello/world",
+	  "httpMethod": "POST",
+	  "headers": {
+		  "Accept": "*/*",
+		  "Accept-Encoding": "gzip, deflate",
+		  "cache-control": "no-cache",
+		  "CloudFront-Forwarded-Proto": "https",
+		  "CloudFront-Is-Desktop-Viewer": "true",
+		  "CloudFront-Is-Mobile-Viewer": "false",
+		  "CloudFront-Is-SmartTV-Viewer": "false",
+		  "CloudFront-Is-Tablet-Viewer": "false",
+		  "CloudFront-Viewer-Country": "US",
+		  "Content-Type": "application/json",
+		  "headerName": "headerValue",
+		  "Host": "gy415nuibc.execute-api.us-east-1.amazonaws.com",
+		  "Postman-Token": "9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f",
+		  "User-Agent": "PostmanRuntime/2.4.5",
+		  "Via": "1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)",
+		  "X-Amz-Cf-Id": "pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==",
+		  "X-Forwarded-For": "54.240.196.186, 54.182.214.83",
+		  "X-Forwarded-Port": "443",
+		  "X-Forwarded-Proto": "https"
+	},
+	"queryStringParameters": {
+		"name": "me"   
+	},
+	"pathParameters": {
+		"proxy": "hello/world"
+	},
+	"stageVariables": {
+		"stageVariableName": "stageVariableValue"
+	},
+	"requestContext": {
+		"accountId": "12345678912",
+		"resourceId": "roq9wj",
+		"stage": "testStage",
+		"requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
+		"identity": {
+			"cognitoIdentityPoolId": "theCognitoIdentityPoolId",
+			"accountId": "theAccountId",
+			"cognitoIdentityId": "theCognitoIdentityId",
+			"caller": "theCaller",
+			"apiKey": "theApiKey",
+			"sourceIp": "192.168.196.186",
+			"cognitoAuthenticationType": "theCognitoAuthenticationType",
+			"cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",
+			"userArn": "theUserArn",
+			"userAgent": "PostmanRuntime/2.4.5",
+			"user": "theUser"
 		},
-		"queryStringParameters": {
-			"name": "me"   
-		},
-		"pathParameters": {
-			"proxy": "hello/world"
-		},
-		"stageVariables": {
-			"stageVariableName": "stageVariableValue"
-		},
-		"requestContext": {
-			"accountId": "12345678912",
-			"resourceId": "roq9wj",
-			"stage": "testStage",
-			"requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
-			"identity": {
-				"cognitoIdentityPoolId": "theCognitoIdentityPoolId",
-				"accountId": "theAccountId",
-				"cognitoIdentityId": "theCognitoIdentityId",
-				"caller": "theCaller",
-				"apiKey": "theApiKey",
-				"sourceIp": "192.168.196.186",
-				"cognitoAuthenticationType": "theCognitoAuthenticationType",
-				"cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",
-				"userArn": "theUserArn",
-				"userAgent": "PostmanRuntime/2.4.5",
-				"user": "theUser"
-			},
-			"resourcePath": "/{proxy+}",
-			"httpMethod": "POST",
-			"apiId": "gy415nuibc"
-		},
-		"body": "{\r\n\t\"a\": 1\r\n}"
-	}
-    
+		"authorizer": {
+			"principalId": "admin",
+			"clientId": 1,
+			"clientName": "Exata"
+		},	
+		"resourcePath": "/{proxy+}",
+		"httpMethod": "POST",
+		"apiId": "gy415nuibc"
+	},
+	"body": "{\r\n\t\"a\": 1\r\n}"
+}


### PR DESCRIPTION
This PR enables parsing of the [Custom Authorizer Context](https://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output) as a map. 

The previous implementation was based on the example found in the link above, and did not allow for custom keys.