### PR TITLE
Add custom authorizer request and response

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -6,6 +6,8 @@ This package provides input types for Lambda functions that process AWS events.
 
 [API Gateway](README_ApiGatewayEvent.md)
 
+[API Gateway Custom Authorizer](README_ApiGatewayCustomAuthorizer.md)
+
 [Cognito Events](README_Cognito.md)
 
 [Config Events](README_Config.md)

--- a/events/README_ApiGatewayCustomAuthorizer.md
+++ b/events/README_ApiGatewayCustomAuthorizer.md
@@ -1,0 +1,67 @@
+# Sample Function
+
+The following is a simple TOKEN authorizer example to demonstrate how to use an authorization 
+token to allow or deny a request. In this example, the caller named "user" is allowed to invoke 
+a request if the client-supplied token value is "allow". The caller is not allowed to invoke 
+the request if the token value is "deny". If the token value is "Unauthorized", the function 
+returns the "Unauthorized" error with an HTTP status code of 401. For any other token value, 
+the authorizer returns an "Invalid token" error. 
+
+This example is based on the [JavaScript sample](https://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-token-lambda-function-create) from the API Gateway documentation
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// Help function to generate an IAM policy
+func generatePolicy(principalId, effect, resource string) events.APIGatewayCustomAuthorizerResponse {
+	authResponse := events.APIGatewayCustomAuthorizerResponse{PrincipalID: principalId}
+
+	if effect != "" && resource != "" {
+		authResponse.PolicyDocument = events.APIGatewayCustomAuthorizerPolicy{
+			Version: "2012-10-17",
+			Statement: []events.IAMPolicyStatement{
+				{
+					Action:   []string{"execute-api:Invoke"},
+					Effect:   effect,
+					Resource: []string{resource},
+				},
+			},
+		}
+	}
+
+	// Optional output with custom properties of the String, Number or Boolean type.
+	authResponse.Context = map[string]interface{}{
+		"stringKey":  "stringval",
+		"numberKey":  123,
+		"booleanKey": true,
+	}
+	return authResponse
+}
+
+func handleRequest(ctx context.Context, event events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error) {
+	token := event.AuthorizationToken
+	switch strings.ToLower(token) {
+	case "allow":
+		return generatePolicy("user", "Allow", event.MethodArn), nil
+	case "deny":
+		return generatePolicy("user", "Deny", event.MethodArn), nil
+	case "unauthorized":
+		return events.APIGatewayCustomAuthorizerResponse{}, errors.New("Unauthorized") // Return a 401 Unauthorized response
+	default:
+		return events.APIGatewayCustomAuthorizerResponse{}, errors.New("Error: Invalid token")
+	}
+}
+
+func main() {
+	lambda.Start(handleRequest)
+}
+```

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -61,3 +61,30 @@ type APIGatewayCustomAuthorizerContext struct {
 	NumKey      *int    `json:"numKey,omitempty"`
 	BoolKey     *bool   `json:"boolKey,omitempty"`
 }
+
+// APIGatewayCustomAuthorizerRequest contains data coming in to a custom API Gateway authorizer function.
+type APIGatewayCustomAuthorizerRequest struct {
+	Type               string `json:"type"`
+	AuthorizationToken string `json:"authorizationToken"`
+	MethodArn          string `json:"methodArn"`
+}
+
+// APIGatewayCustomAuthorizerResponse represents the expected format of an API Gateway authorization response.
+type APIGatewayCustomAuthorizerResponse struct {
+	PrincipalID        string                           `json:"principalId"`
+	PolicyDocument     APIGatewayCustomAuthorizerPolicy `json:"policyDocument"`
+	Context            map[string]interface{}           `json:"context,omitempty"`
+	UsageIdentifierKey string                           `json:"usageIdentifierKey,omitempty"`
+}
+
+// APIGatewayCustomAuthorizerPolicy represents an IAM policy
+type APIGatewayCustomAuthorizerPolicy struct {
+	Version   string
+	Statement []IAMPolicyStatement
+}
+
+type IAMPolicyStatement struct {
+	Action   string
+	Effect   string
+	Resource string
+}

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -84,7 +84,7 @@ type APIGatewayCustomAuthorizerPolicy struct {
 }
 
 type IAMPolicyStatement struct {
-	Action   string
+	Action   []string
 	Effect   string
-	Resource string
+	Resource []string
 }

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -71,3 +71,57 @@ func TestApiGatewayResponseMarshaling(t *testing.T) {
 func TestApiGatewayResponseMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, APIGatewayProxyResponse{})
 }
+
+func TestApiGatewayCustomAuthorizerRequestMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent APIGatewayCustomAuthorizerRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
+func TestApiGatewayCustomAuthorizerRequestMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, APIGatewayCustomAuthorizerRequest{})
+}
+
+func TestApiGatewayCustomAuthorizerResponseMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-response.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent APIGatewayCustomAuthorizerResponse
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
+func TestApiGatewayCustomAuthorizerResponseMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, APIGatewayCustomAuthorizerResponse{})
+}

--- a/events/testdata/apigw-custom-auth-request.json
+++ b/events/testdata/apigw-custom-auth-request.json
@@ -1,0 +1,5 @@
+{
+    "type":"TOKEN",
+    "authorizationToken":"allow",
+    "methodArn":"arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/*/GET/"
+}

--- a/events/testdata/apigw-custom-auth-response.json
+++ b/events/testdata/apigw-custom-auth-response.json
@@ -4,9 +4,9 @@
       "Version": "2012-10-17",
       "Statement": [
         {
-          "Action": "execute-api:Invoke",
+          "Action": ["execute-api:Invoke"],
           "Effect": "Allow|Deny",
-          "Resource": "arn:aws:execute-api:{regionId}:{accountId}:{appId}/{stage}/{httpVerb}/[{resource}/[child-resources]]"
+          "Resource": ["arn:aws:execute-api:{regionId}:{accountId}:{appId}/{stage}/{httpVerb}/[{resource}/[child-resources]]"]
         }
       ]
     },

--- a/events/testdata/apigw-custom-auth-response.json
+++ b/events/testdata/apigw-custom-auth-response.json
@@ -1,0 +1,19 @@
+{
+    "principalId": "yyyyyyyy",
+    "policyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "execute-api:Invoke",
+          "Effect": "Allow|Deny",
+          "Resource": "arn:aws:execute-api:{regionId}:{accountId}:{appId}/{stage}/{httpVerb}/[{resource}/[child-resources]]"
+        }
+      ]
+    },
+    "context": {
+      "stringKey": "value",
+      "numberKey": "1",
+      "booleanKey": "true"
+    },
+    "usageIdentifierKey": "{api-key}"
+}


### PR DESCRIPTION
This PR introduces the required structs for implementing an APIGW Custom Authorizer, as described in https://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html