### PR TITLE
update imports in s3 event readme

### DIFF
--- a/events/README_S3.md
+++ b/events/README_S3.md
@@ -5,8 +5,10 @@ The following is a sample class and Lambda function that receives Amazon S3 even
 ```go
 
 import (
-    "strings"
-    "github.com/aws/aws-lambda-go/events")
+    "fmt"
+    "context"
+    "github.com/aws/aws-lambda-go/events"
+)
 
 func handler(ctx context.Context, s3Event events.S3Event) {
     for _, record := range s3Event.Records {


### PR DESCRIPTION
fmt and context weren't imported and strings was never used. Also moved the closing parenthesis onto a new line.