### PR TITLE
Add `UserIdentity` field to events.DynamoDBEventRecord

### DIFF
--- a/events/dynamodb.go
+++ b/events/dynamodb.go
@@ -44,6 +44,23 @@ type DynamoDBEventRecord struct {
 
 	// The event source ARN of DynamoDB
 	EventSourceArn string `json:"eventSourceARN"`
+
+	// Items that are deleted by the Time to Live process after expiration have
+	// the following fields:
+	//
+	//    * Records[].userIdentity.type
+	//
+	// "Service"
+	//
+	//    * Records[].userIdentity.principalId
+	//
+	// "dynamodb.amazonaws.com"
+	UserIdentity DynamoDBUserIdentity `json:"userIdentity"`
+}
+
+type DynamoDBUserIdentity struct {
+	Type        string `json:"type"`
+	PrincipleID string `json:"principalId"`
 }
 
 // A description of a single data modification that was performed on an item


### PR DESCRIPTION
Records streamed into DynamoDB Streams may have UserIdentity field.
https://github.com/aws/aws-sdk-go/blob/master/service/dynamodbstreams/api.go#L874-L920
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-streams.html
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_Record.html

Ref: same modification for apex-go https://github.com/apex/apex-go/pull/64