### PR TITLE
Fix provided example

### DIFF
--- a/events/README_Kinesis.md
+++ b/events/README_Kinesis.md
@@ -4,18 +4,30 @@ The following is a sample class and Lambda function that receives Amazon Kinesis
 
 ```go
 
-import (
-    "strings"
-    "github.com/aws/aws-lambda-go/events")
+package main
 
-func handler(ctx context.Context, kinesisEvent events.KinesisEvent) {
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+func handler(ctx context.Context, kinesisEvent events.KinesisEvent) error {
     for _, record := range kinesisEvent.Records {
         kinesisRecord := record.Kinesis
-        dataBytes := kinesisRecordData.Data
+        dataBytes := kinesisRecord.Data
         dataText := string(dataBytes)
 
         fmt.Printf("%s Data = %s \n", record.EventName, dataText) 
     }
+    
+    return nil
+}
+
+func main() {
+	lambda.Start(handler)
 }
 
 ```


### PR DESCRIPTION
Hi!

The example does not work as is. The function that handle the request needs to return at least an error to have a valid signature (see [here](https://github.com/aws/aws-lambda-go/blob/master/lambda/entry.go#L25)).

Here is a full code example.