### PR TITLE
Add SES event

### DIFF
--- a/events/ses.go
+++ b/events/ses.go
@@ -1,0 +1,64 @@
+package events
+
+import "time"
+
+// SimpleEmailEvent is the outer structure of an event sent via SES.
+type SimpleEmailEvent struct {
+	Records []SimpleEmailRecord `json:"Records"`
+}
+
+type SimpleEmailRecord struct {
+	EventVersion string             `json:"eventVersion"`
+	EventSource  string             `json:"eventSource"`
+	SES          SimpleEmailService `json:"ses"`
+}
+
+type SimpleEmailService struct {
+	Mail    SimpleEmailMessage `json:"mail"`
+	Receipt SimpleEmailReceipt `json:"receipt"`
+}
+
+type SimpleEmailMessage struct {
+	CommonHeaders    SimpleEmailCommonHeaders `json:"commonHeaders"`
+	Source           string                   `json:"source"`
+	Timestamp        time.Time                `json:"timestamp"`
+	Destination      []string                 `json:"destination"`
+	Headers          []SimpleEmailHeader      `json:"headers"`
+	HeadersTruncated bool                     `json:"headersTruncated"`
+	MessageID        string                   `json:"messageId"`
+}
+
+type SimpleEmailReceipt struct {
+	Recipients           []string                 `json:"recipients"`
+	Timestamp            time.Time                `json:"timestamp"`
+	SpamVerdict          SimpleEmailVerdict       `json:"spamVerdict"`
+	DKIMVerdict          SimpleEmailVerdict       `json:"dkimVerdict"`
+	SPFVerdict           SimpleEmailVerdict       `json:"spfVerdict"`
+	VirusVerdict         SimpleEmailVerdict       `json:"virusVerdict"`
+	Action               SimpleEmailReceiptAction `json:"action"`
+	ProcessingTimeMillis int64                    `json:"processingTimeMillis"`
+}
+
+type SimpleEmailHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type SimpleEmailCommonHeaders struct {
+	From       []string `json:"from"`
+	To         []string `json:"to"`
+	ReturnPath string   `json:"returnPath"`
+	MessageID  string   `json:"messageId"`
+	Date       string   `json:"date"`
+	Subject    string   `json:"subject"`
+}
+
+type SimpleEmailReceiptAction struct {
+	Type           string `json:"type"`
+	InvocationType string `json:"invocationType"`
+	FunctionArn    string `json:"functionArn"`
+}
+
+type SimpleEmailVerdict struct {
+	Status string `json:"status"`
+}

--- a/events/ses_test.go
+++ b/events/ses_test.go
@@ -1,0 +1,28 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events/test"
+)
+
+func TestSESEventMarshaling(t *testing.T) {
+	inputJSON := readJsonFromFile(t, "./testdata/ses-event.json")
+
+	var inputEvent SimpleEmailEvent
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
+func TestSESMarshalingMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, SimpleEmailEvent{})
+}

--- a/events/testdata/ses-event.json
+++ b/events/testdata/ses-event.json
@@ -1,0 +1,97 @@
+{
+  "Records": [
+    {
+      "eventVersion": "1.0",
+      "ses": {
+        "mail": {
+          "commonHeaders": {
+            "from": [
+              "Amazon Web Services <aws@amazon.com>"
+            ],
+            "to": [
+              "lambda@amazon.com"
+            ],
+            "returnPath": "aws@amazon.com",
+            "messageId": "<CAEddw6POFV_On91m+ZoL_SN8B_M2goDe_Ni355owhc7QSjPQSQ@amazon.com>",
+            "date": "Mon, 5 Dec 2016 18:40:08 -0800",
+            "subject": "Test Subject"
+          },
+          "source": "aws@amazon.com",
+          "timestamp": "1970-01-01T00:00:00.123Z",
+          "destination": [
+            "lambda@amazon.com"
+          ],
+          "headers": [
+            {
+              "name": "Return-Path",
+              "value": "<aws@amazon.com>"
+            },
+            {
+              "name": "Received",
+              "value": "from mx.amazon.com (mx.amazon.com [127.0.0.1]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id 6n4thuhcbhpfiuf25gshf70rss364fuejrvmqko1 for lambda@amazon.com; Tue, 06 Dec 2016 02:40:10 +0000 (UTC)"
+            },
+            {
+              "name": "DKIM-Signature",
+              "value": "v=1; a=rsa-sha256; c=relaxed/relaxed; d=iatn.net; s=amazon; h=mime-version:from:date:message-id:subject:to; bh=chlJxa/vZ11+0O9lf4tKDM/CcPjup2nhhdITm+hSf3c=; b=SsoNPK0wX7umtWnw8pln3YSib+E09XO99d704QdSc1TR1HxM0OTti/UaFxVD4e5b0+okBqo3rgVeWgNZ0sWZEUhBaZwSL3kTd/nHkcPexeV0XZqEgms1vmbg75F6vlz9igWflO3GbXyTRBNMM0gUXKU/686hpVW6aryEIfM/rLY="
+            },
+            {
+              "name": "MIME-Version",
+              "value": "1.0"
+            },
+            {
+              "name": "From",
+              "value": "Amazon Web Services <aws@amazon.com>"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 5 Dec 2016 18:40:08 -0800"
+            },
+            {
+              "name": "Message-ID",
+              "value": "<CAEddw6POFV_On91m+ZoL_SN8B_M2goDe_Ni355owhc7QSjPQSQ@amazon.com>"
+            },
+            {
+              "name": "Subject",
+              "value": "Test Subject"
+            },
+            {
+              "name": "To",
+              "value": "lambda@amazon.com"
+            },
+            {
+              "name": "Content-Type",
+              "value": "multipart/alternative; boundary=94eb2c0742269658b10542f452a9"
+            }
+          ],
+          "headersTruncated": false,
+          "messageId": "6n4thuhcbhpfiuf25gshf70rss364fuejrvmqko1"
+        },
+        "receipt": {
+          "recipients": [
+            "lambda@amazon.com"
+          ],
+          "timestamp": "1970-01-01T00:00:00.123Z",
+          "spamVerdict": {
+            "status": "PASS"
+          },
+          "dkimVerdict": {
+            "status": "PASS"
+          },
+          "processingTimeMillis": 574,
+          "action": {
+            "type": "Lambda",
+            "invocationType": "Event",
+            "functionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-ses-lambda-function"
+          },
+          "spfVerdict": {
+            "status": "PASS"
+          },
+          "virusVerdict": {
+            "status": "PASS"
+          }
+        }
+      },
+      "eventSource": "aws:ses"
+    }
+  ]
+}


### PR DESCRIPTION
This PR enables parsing of the SES event.

Maybe, the sample event of SES listed on [this document](https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/eventsources.html#eventsources-ses-email-receiving) is for SNS.