### PR TITLE
API Gateway custom authorizer request type structs

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -53,6 +53,12 @@ type APIGatewayRequestIdentity struct {
 	User                          string `json:"user"`
 }
 
+// APIGatewayCustomAuthorizerRequestTypeRequestIdentity contains identity information for the request caller.
+type APIGatewayCustomAuthorizerRequestTypeRequestIdentity struct {
+	APIKey   string `json:"apiKey"`
+	SourceIP string `json:"sourceIp"`
+}
+
 // APIGatewayCustomAuthorizerContext represents the expected format of an API Gateway custom authorizer response.
 // Deprecated. Code should be updated to use the Authorizer map from APIGatewayRequestIdentity. Ex: Authorizer["principalId"]
 type APIGatewayCustomAuthorizerContext struct {
@@ -62,11 +68,38 @@ type APIGatewayCustomAuthorizerContext struct {
 	BoolKey     *bool   `json:"boolKey,omitempty"`
 }
 
+// APIGatewayCustomAuthorizerRequestTypeRequestContext represents the expected format of an API Gateway custom authorizer response.
+type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
+	Path         string                                               `json:"path"`
+	AccountID    string                                               `json:"accountId"`
+	ResourceID   string                                               `json:"resourceId"`
+	Stage        string                                               `json:"stage"`
+	RequestID    string                                               `json:"requestId"`
+	Identity     APIGatewayCustomAuthorizerRequestTypeRequestIdentity `json:"identity"`
+	ResourcePath string                                               `json:"resourcePath"`
+	HTTPMethod   string                                               `json:"httpMethod"`
+	APIID        string                                               `json:"apiId"`
+}
+
 // APIGatewayCustomAuthorizerRequest contains data coming in to a custom API Gateway authorizer function.
 type APIGatewayCustomAuthorizerRequest struct {
 	Type               string `json:"type"`
 	AuthorizationToken string `json:"authorizationToken"`
 	MethodArn          string `json:"methodArn"`
+}
+
+// APIGatewayCustomAuthorizerRequestTypeRequest contains data coming in to a custom API Gateway authorizer function.
+type APIGatewayCustomAuthorizerRequestTypeRequest struct {
+	Type                  string                                              `json:"type"`
+	MethodArn             string                                              `json:"methodArn"`
+	Resource              string                                              `json:"resource"`
+	Path                  string                                              `json:"path"`
+	HTTPMethod            string                                              `json:"httpMethod"`
+	Headers               map[string]string                                   `json:"headers"`
+	QueryStringParameters map[string]string                                   `json:"queryStringParameters"`
+	PathParameters        map[string]string                                   `json:"pathParameters"`
+	StageVariables        map[string]string                                   `json:"stageVariables"`
+	RequestContext        APIGatewayCustomAuthorizerRequestTypeRequestContext `json:"requestContext"`
 }
 
 // APIGatewayCustomAuthorizerResponse represents the expected format of an API Gateway authorization response.

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -95,8 +95,35 @@ func TestApiGatewayCustomAuthorizerRequestMarshaling(t *testing.T) {
 	test.AssertJsonsEqual(t, inputJSON, outputJSON)
 }
 
+func TestApiGatewayCustomAuthorizerRequestTypeRequestMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-request-type-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent APIGatewayCustomAuthorizerRequestTypeRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
 func TestApiGatewayCustomAuthorizerRequestMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, APIGatewayCustomAuthorizerRequest{})
+}
+
+func TestApiGatewayCustomAuthorizerRequestTypeRequestMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, APIGatewayCustomAuthorizerRequestTypeRequest{})
 }
 
 func TestApiGatewayCustomAuthorizerResponseMarshaling(t *testing.T) {

--- a/events/testdata/apigw-custom-auth-request-type-request.json
+++ b/events/testdata/apigw-custom-auth-request-type-request.json
@@ -1,0 +1,51 @@
+{
+    "type": "REQUEST",
+    "methodArn": "arn:aws:execute-api:us-east-1:123456789012:s4x3opwd6i/test/GET/request",
+    "resource": "/request",
+    "path": "/request",
+    "httpMethod": "GET",
+    "headers": {
+        "X-AMZ-Date": "20170718T062915Z",
+        "Accept": "*/*",
+        "HeaderAuth1": "headerValue1",
+        "CloudFront-Viewer-Country": "US",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "User-Agent": "...",
+        "X-Forwarded-Proto": "https",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "Host": "....execute-api.us-east-1.amazonaws.com",
+        "Accept-Encoding": "gzip, deflate",
+        "X-Forwarded-Port": "443",
+        "X-Amzn-Trace-Id": "...",
+        "Via": "...cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "...",
+        "X-Forwarded-For": "..., ...",
+        "Postman-Token": "...",
+        "cache-control": "no-cache",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "Content-Type": "application/x-www-form-urlencoded"
+    },
+    "queryStringParameters": {
+        "QueryString1": "queryValue1"
+    },
+    "pathParameters": {},
+    "stageVariables": {
+        "StageVar1": "stageValue1"
+    },
+    "requestContext": {
+        "path": "/request",
+        "accountId": "123456789012",
+        "resourceId": "05c7jb",
+        "stage": "test",
+        "requestId": "...",
+        "identity": {
+            "apiKey": "...",
+            "sourceIp": "..."
+        },
+        "resourcePath": "/request",
+        "httpMethod": "GET",
+        "apiId": "s4x3opwd6i"
+    }
+}


### PR DESCRIPTION
An API Gateway Custom Authorizer supports two request types --
token and request. The existing structs are for the token type of
request. This commit adds the request type of request.

Fixes #61.