### PR TITLE
Start() to allow customizable Interface to be passed as wrapper handler

### DIFF
--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -38,23 +38,23 @@ import (
 // See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves
 func Start(handler interface{}) {
 	wrappedHandler := newHandler(handler)
-	StartWrapper(wrappedHandler)
+	StartHandler(wrappedHandler)
 }
 
-// StartWrapper takes in a LambdaHandler wrapper interface which can be implemented either by a
+// StartHandler takes in a Handler wrapper interface which can be implemented either by a
 // custom function or a struct.
 //
-// LambdaHandler wrapper implementation requires a single "Invoke()" function:
+// Handler implementation requires a single "Invoke()" function:
 //
 //  func Invoke(context.Context, []byte) ([]byte, error)
-func StartWrapper(wrappedHandler LambdaHandler) {
+func StartHandler(handler Handler) {
 	port := os.Getenv("_LAMBDA_SERVER_PORT")
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
 	function := new(Function)
-	function.handler = wrappedHandler
+	function.handler = handler
 	err = rpc.Register(function)
 	if err != nil {
 		log.Fatal("failed to register handler function")

--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -44,7 +44,7 @@ func Start(handler interface{}) {
 	}
 	wrappedHandler := newHandler(handler)
 	function := new(Function)
-	function.handler = wrappedHandler
+	function.Handler = wrappedHandler
 	err = rpc.Register(function)
 	if err != nil {
 		log.Fatal("failed to register handler function")

--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -37,14 +37,24 @@ import (
 // Where "TIn" and "TOut" are types compatible with the "encoding/json" standard library.
 // See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves
 func Start(handler interface{}) {
+	wrappedHandler := newHandler(handler)
+	StartWrapper(wrappedHandler)
+}
+
+// StartWrapper takes in a LambdaHandler wrapper interface which can be implemented either by a
+// custom function or a struct.
+//
+// LambdaHandler wrapper implementation requires a single "Invoke()" function:
+//
+//  func Invoke(context.Context, []byte) ([]byte, error)
+func StartWrapper(wrappedHandler LambdaHandler) {
 	port := os.Getenv("_LAMBDA_SERVER_PORT")
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
-	wrappedHandler := newHandler(handler)
 	function := new(Function)
-	function.Handler = wrappedHandler
+	function.handler = wrappedHandler
 	err = rpc.Register(function)
 	if err != nil {
 		log.Fatal("failed to register handler function")

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Function struct {
-	handler lambdaHandler
+	Handler LambdaHandler
 }
 
 func (fn *Function) Ping(req *messages.PingRequest, response *messages.PingResponse) error {
@@ -56,7 +56,7 @@ func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.Invok
 
 	invokeContext = context.WithValue(invokeContext, "x-amzn-trace-id", req.XAmznTraceId)
 
-	payload, err := fn.handler.Invoke(invokeContext, req.Payload)
+	payload, err := fn.Handler.Invoke(invokeContext, req.Payload)
 	if err != nil {
 		response.Error = lambdaErrorResponse(err)
 		return nil

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Function struct {
-	Handler LambdaHandler
+	handler LambdaHandler
 }
 
 func (fn *Function) Ping(req *messages.PingRequest, response *messages.PingResponse) error {
@@ -56,7 +56,7 @@ func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.Invok
 
 	invokeContext = context.WithValue(invokeContext, "x-amzn-trace-id", req.XAmznTraceId)
 
-	payload, err := fn.Handler.Invoke(invokeContext, req.Payload)
+	payload, err := fn.handler.Invoke(invokeContext, req.Payload)
 	if err != nil {
 		response.Error = lambdaErrorResponse(err)
 		return nil

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Function struct {
-	handler LambdaHandler
+	handler Handler
 }
 
 func (fn *Function) Ping(req *messages.PingRequest, response *messages.PingResponse) error {

--- a/lambda/function_test.go
+++ b/lambda/function_test.go
@@ -31,8 +31,8 @@ func (h testWrapperHandler) Invoke(ctx context.Context, payload []byte) ([]byte,
 	return responseBytes, nil
 }
 
-// verify testWrapperHandler implements LambdaHandler
-var _ LambdaHandler = (testWrapperHandler)(nil)
+// verify testWrapperHandler implements Handler
+var _ Handler = (testWrapperHandler)(nil)
 
 func TestInvoke(t *testing.T) {
 	srv := &Function{handler: testWrapperHandler(

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 )
 
-type LambdaHandler interface {
+type Handler interface {
 	Invoke(ctx context.Context, payload []byte) ([]byte, error)
 }
 

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -9,6 +9,10 @@ import (
 	"reflect"
 )
 
+type LambdaHandler interface {
+	Invoke(ctx context.Context, payload []byte) ([]byte, error)
+}
+
 // lambdaHandler is the generic function type
 type lambdaHandler func(context.Context, []byte) (interface{}, error)
 


### PR DESCRIPTION
I realize that the current design is to abstract away the inner workings of both `Function` and `lambdaHandler`, letting the user go through `Start()` entry point only.

However there are some valid scenarios when a user may wish to implement their own wrapper handlers to deal with the raw `[]byte` slice such as:

- writing a custom handler that is specific rather than generic, thus not having to rely on reflection.
- non JSON scenarios such as [APIGateway binary data](https://aws.amazon.com/about-aws/whats-new/2016/11/binary-data-now-supported-by-api-gateway/), [Protobuf](https://theburningmonk.com/2017/09/using-protocol-buffers-with-api-gateway-and-aws-lambda/) or something like LIBSVM, which would fall out of the default `encoding/json` imposed by `lambdaHandler`. 

The way I've refactored is to make `lambdaHandler` implement a interface called `LambdaHandler`. This way the current inner workings are still hidden, and users would pass through their custom `LamdbaHandler` via a new `StartWrapper()` entrypoint. 

An alternative would be to expose the function type of `lambdaHandler`. However, an interface seems more appropriate since
- `lambdaHandler` is already treated like an interface by calling the `Invoke()` method instead of being called as a function: https://github.com/aws/aws-lambda-go/blob/master/lambda/function.go#L59
- function implementation can have different signature to the `Invoke()` function, i.e. returning `interface{}` instead of `[]byte`: https://github.com/aws/aws-lambda-go/blob/master/lambda/handler.go#L13
- can be implemented using structs instead of functions
