### PR TITLE
Add functions to initialize DynamoDBAttributeValue

### DIFF
--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -119,11 +119,74 @@ func (av DynamoDBAttributeValue) DataType() DynamoDBDataType {
 	return av.dataType
 }
 
+// NewBinaryAttribute creates an DynamoDBAttributeValue containing a Binary
+func NewBinaryAttribute(value []byte) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeBinary
+	return av
+}
+
+// NewBooleanAttribute creates an DynamoDBAttributeValue containing a Boolean
+func NewBooleanAttribute(value bool) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeBoolean
+	return av
+}
+
+// NewBinarySetAttribute creates an DynamoDBAttributeValue containing a BinarySet
+func NewBinarySetAttribute(value [][]byte) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeBinarySet
+	return av
+}
+
+// NewListAttribute creates an DynamoDBAttributeValue containing a List
+func NewListAttribute(value []DynamoDBAttributeValue) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeList
+	return av
+}
+
+// NewMapAttribute creates an DynamoDBAttributeValue containing a Map
+func NewMapAttribute(value map[string]DynamoDBAttributeValue) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeMap
+	return av
+}
+
+// NewNumberAttribute creates an DynamoDBAttributeValue containing a Number
+func NewNumberAttribute(value string) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeNumber
+	return av
+}
+
+// NewNullAttribute creates an DynamoDBAttributeValue containing a Null
+func NewNullAttribute() DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.dataType = DataTypeNull
+	return av
+}
+
 // NewStringAttribute creates an DynamoDBAttributeValue containing a String
 func NewStringAttribute(value string) DynamoDBAttributeValue {
 	var av DynamoDBAttributeValue
 	av.value = value
 	av.dataType = DataTypeString
+	return av
+}
+
+// NewStringSetAttribute creates an DynamoDBAttributeValue containing a StringSet
+func NewStringSetAttribute(value []string) DynamoDBAttributeValue {
+	var av DynamoDBAttributeValue
+	av.value = value
+	av.dataType = DataTypeStringSet
 	return av
 }
 

--- a/events/attributevalue_test.go
+++ b/events/attributevalue_test.go
@@ -63,7 +63,7 @@ func TestUnmarshalList(t *testing.T) {
 
 func TestUnmarshalMap(t *testing.T) {
 	input := []byte(`
-        { "M": 
+        { "M":
             {
                 "Name": { "S": "Joe" },
                 "Age":  { "N": "35" }
@@ -245,4 +245,70 @@ func TestMarshalAndUnmarshalString(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, DataTypeString, av.DataType())
 	assert.Equal(t, inputString, av.String())
+}
+
+func Test_DynamoDBAttributeValue_NewAttribute(t *testing.T) {
+	{
+		av := NewBinaryAttribute([]byte{1, 2, 3})
+		assert.Equal(t, DataTypeBinary, av.DataType())
+		assert.Equal(t, []byte{1, 2, 3}, av.Binary())
+	}
+	{
+		av := NewBooleanAttribute(true)
+		assert.Equal(t, DataTypeBoolean, av.DataType())
+		assert.Equal(t, true, av.Boolean())
+	}
+	{
+		av := NewBinarySetAttribute([][]byte{[]byte{1, 2, 3}})
+		assert.Equal(t, DataTypeBinarySet, av.DataType())
+		assert.Equal(t, [][]byte{[]byte{1, 2, 3}}, av.BinarySet())
+	}
+	{
+		av := NewListAttribute([]DynamoDBAttributeValue{
+			NewNumberAttribute("1"),
+			NewStringAttribute("test"),
+		})
+		assert.Equal(t, DataTypeList, av.DataType())
+		assert.Equal(t, 2, len(av.List()))
+	}
+	{
+		value := map[string]DynamoDBAttributeValue{
+			"n": NewNumberAttribute("1"),
+			"s": NewStringAttribute("test"),
+		}
+		av := NewMapAttribute(value)
+		assert.Equal(t, DataTypeMap, av.DataType())
+		assert.Equal(t, 2, len(av.Map()))
+	}
+	{
+		av := NewNumberAttribute("1")
+		assert.Equal(t, DataTypeNumber, av.DataType())
+		assert.Equal(t, "1", av.Number())
+		v, err := av.Integer()
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1), v)
+	}
+	{
+		av := NewNumberAttribute("1.1")
+		assert.Equal(t, DataTypeNumber, av.DataType())
+		assert.Equal(t, "1.1", av.Number())
+		v, err := av.Float()
+		assert.Nil(t, err)
+		assert.Equal(t, float64(1.1), v)
+	}
+	{
+		av := NewNullAttribute()
+		assert.Equal(t, DataTypeNull, av.DataType())
+		assert.Equal(t, true, av.IsNull())
+	}
+	{
+		av := NewStringAttribute("test")
+		assert.Equal(t, DataTypeString, av.DataType())
+		assert.Equal(t, "test", av.String())
+	}
+	{
+		av := NewStringSetAttribute([]string{"test", "test"})
+		assert.Equal(t, DataTypeStringSet, av.DataType())
+		assert.Equal(t, []string{"test", "test"}, av.StringSet())
+	}
 }


### PR DESCRIPTION
My motivation is to test and take a benchmark around `DynamoDBStreamRecord`.
But only `NewStringAttribute` is supported and `DynamoDBAttributeValue` doesn't have exported fields so we cloudn't make sample data.

I followed the function name policy of `NewStringAttribute` but is it ok??