### PR TITLE
lambdacontext: Add Deadline to the context

### DIFF
--- a/lambda/function.go
+++ b/lambda/function.go
@@ -45,6 +45,7 @@ func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.Invok
 			CognitoIdentityID:     req.CognitoIdentityId,
 			CognitoIdentityPoolID: req.CognitoIdentityPoolId,
 		},
+		Deadline: deadline,
 	}
 	if len(req.ClientContext) > 0 {
 		if err := json.Unmarshal(req.ClientContext, &lc.ClientContext); err != nil {

--- a/lambdacontext/context.go
+++ b/lambdacontext/context.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"time"
 )
 
 // LogGroupName is the name of the log group that contains the log streams of the current Lambda Function
@@ -66,6 +67,7 @@ type LambdaContext struct {
 	InvokedFunctionArn string
 	Identity           CognitoIdentity
 	ClientContext      ClientContext
+	Deadline           time.Time
 }
 
 // An unexported type to be used as the key for types in this package.


### PR DESCRIPTION
This change adds the deadline to the LambdaContext type. This will allow
users to know how much time is remaining for a given invocation.

Using `time.Until` on the deadline is similar to the
`get_remaining_time_in_millis` method for the Python context object. See
https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html.