### PR TITLE
fix DialogAction.ResponseCard serialization issue

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -38,7 +38,7 @@ type LexDialogAction struct {
 	IntentName       string            `json:"intentName,omitempty"`
 	Slots            Slots             `json:"slots,omitempty"`
 	SlotToElicit     string            `json:"slotToElicit,omitempty"`
-	ResponseCard     LexResponseCard   `json:"responseCard,omitempty"`
+	ResponseCard     *LexResponseCard  `json:"responseCard,omitempty"`
 }
 
 type Slots map[string]string


### PR DESCRIPTION
fixes #66 

declares `DialogAction.ResponseCard` as a pointer, so it is completely omitted from its json representation when nil.