### PR TITLE
Add missing dmarcVerdict to the SimpleEmailReceipt

### DIFF
--- a/events/ses.go
+++ b/events/ses.go
@@ -33,6 +33,7 @@ type SimpleEmailReceipt struct {
 	Timestamp            time.Time                `json:"timestamp"`
 	SpamVerdict          SimpleEmailVerdict       `json:"spamVerdict"`
 	DKIMVerdict          SimpleEmailVerdict       `json:"dkimVerdict"`
+	DMARCVerdict	     SimpleEmailVerdict       `json:"dmarcVerdict"`
 	SPFVerdict           SimpleEmailVerdict       `json:"spfVerdict"`
 	VirusVerdict         SimpleEmailVerdict       `json:"virusVerdict"`
 	Action               SimpleEmailReceiptAction `json:"action"`


### PR DESCRIPTION
dmarcVerdict seems to be missing from the SimpleEmailReceipt struct.  This adds it in.