### PR TITLE
Add dmarc policy to SES event

### DIFF
--- a/events/ses.go
+++ b/events/ses.go
@@ -34,6 +34,7 @@ type SimpleEmailReceipt struct {
 	SpamVerdict          SimpleEmailVerdict       `json:"spamVerdict"`
 	DKIMVerdict          SimpleEmailVerdict       `json:"dkimVerdict"`
 	DMARCVerdict         SimpleEmailVerdict       `json:"dmarcVerdict"`
+	DMARCPolicy          SimpleEmailVerdict       `json:"dmarcPolicy"`
 	SPFVerdict           SimpleEmailVerdict       `json:"spfVerdict"`
 	VirusVerdict         SimpleEmailVerdict       `json:"virusVerdict"`
 	Action               SimpleEmailReceiptAction `json:"action"`

--- a/events/testdata/ses-event.json
+++ b/events/testdata/ses-event.json
@@ -80,6 +80,9 @@
           "dmarcVerdict": {
             "status": "PASS"
           },
+          "dmarcPolicy": {
+            "status": "REJECT"
+          },
           "processingTimeMillis": 574,
           "action": {
             "type": "Lambda",


### PR DESCRIPTION
The SES Receipt is missing the attribute for dmarcPolicy of the inbound email.