### PR TITLE
Add disposition type for controlling inbound

### DIFF
--- a/events/ses.go
+++ b/events/ses.go
@@ -63,3 +63,8 @@ type SimpleEmailReceiptAction struct {
 type SimpleEmailVerdict struct {
 	Status string `json:"status"`
 }
+
+// SimpleEmailDisposition disposition return for SES to control rule functions
+type SimpleEmailDisposition struct {
+	Disposition string `json:"disposition"`
+}

--- a/events/ses.go
+++ b/events/ses.go
@@ -64,7 +64,19 @@ type SimpleEmailVerdict struct {
 	Status string `json:"status"`
 }
 
+// SimpleEmailDispositionValue enumeration representing the dispostition value for SES
+type SimpleEmailDispositionValue string
+
+const (
+	// SimpleEmailContinue represents the CONTINUE disposition which tells the SES Rule Set to continue to the next rule
+	SimpleEmailContinue SimpleEmailDispositionValue = "CONTINUE"
+	// SimpleEmailStopRule represents the STOP_RULE disposition which tells the SES Rule Set to stop processing this rule and continue to the next
+	SimpleEmailStopRule SimpleEmailDispositionValue = "STOP_RULE"
+	// SimpleEmailStopRuleSet represents the STOP_RULE_SET disposition which tells the SES Rule SEt to stop processing all rules
+	SimpleEmailStopRuleSet SimpleEmailDispositionValue = "STOP_RULE_SET"
+)
+
 // SimpleEmailDisposition disposition return for SES to control rule functions
 type SimpleEmailDisposition struct {
-	Disposition string `json:"disposition"`
+	Disposition SimpleEmailDispositionValue `json:"disposition"`
 }


### PR DESCRIPTION
To control inbound email, a JSON string of the form `{disposition: <control>}` needs to be returned.  For instance if you want to stop the entire rule set you must return `{disposition: STOP_RULE_SET}` and inbound will stop there at the lambda.  Adding the type to the SES events as this was missing.  I've had to copy this type around to a few internal project and thought it best to centralize.  Let me know if there's a better location for this type.