### PR TITLE
Fix Lex event slots type

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -41,7 +41,7 @@ type LexDialogAction struct {
 	ResponseCard     *LexResponseCard  `json:"responseCard,omitempty"`
 }
 
-type Slots map[string]interface{}
+type Slots map[string]*string
 
 type LexResponseCard struct {
 	Version            int64        `json:"version,omitempty"`

--- a/events/lex.go
+++ b/events/lex.go
@@ -41,7 +41,7 @@ type LexDialogAction struct {
 	ResponseCard     *LexResponseCard  `json:"responseCard,omitempty"`
 }
 
-type Slots map[string]string
+type Slots map[string]interface{}
 
 type LexResponseCard struct {
 	Version            int64        `json:"version,omitempty"`


### PR DESCRIPTION
If you set Slots as "map[string]string", when you send them delegating the action, amazon lex suppose that the next slots have been filled and goes directly to the "FulfillmentCodeHook". So, the type of the slots should be "map[string]interface{}" to send back the slots values as (nil), not empty string ("").