### PR TITLE
update golint install to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 
 install: 
   - dep ensure
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/haya14busa/goverage
 
 matrix:


### PR DESCRIPTION
https://travis-ci.org/aws/aws-lambda-go/builds/440553951 was broken by https://github.com/golang/lint/issues/415