### PR TITLE
Make newhandler public

### DIFF
--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -37,7 +37,7 @@ import (
 // Where "TIn" and "TOut" are types compatible with the "encoding/json" standard library.
 // See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves
 func Start(handler interface{}) {
-	wrappedHandler := newHandler(handler)
+	wrappedHandler := NewHandler(handler)
 	StartHandler(wrappedHandler)
 }
 

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -70,14 +70,17 @@ func validateReturns(handler reflect.Type) error {
 	return nil
 }
 
-// newHandler Creates the base lambda handler, which will do basic payload unmarshaling before defering to handlerSymbol.
-// If handlerSymbol is not a valid handler, the returned function will be a handler that just reports the validation error.
-func newHandler(handlerSymbol interface{}) lambdaHandler {
-	if handlerSymbol == nil {
+// NewHandler creates a base lambda handler from the given handler function. The
+// returned Handler performs JSON deserialization and deserialization, and
+// delegates to the input handler function.  The handler function parameter must
+// satisfy the rules documented by Start.  If handlerFunc is not a valid
+// handler, the returned Handler simply reports the validation error.
+func NewHandler(handlerFunc interface{}) Handler {
+	if handlerFunc == nil {
 		return errorHandler(fmt.Errorf("handler is nil"))
 	}
-	handler := reflect.ValueOf(handlerSymbol)
-	handlerType := reflect.TypeOf(handlerSymbol)
+	handler := reflect.ValueOf(handlerFunc)
+	handlerType := reflect.TypeOf(handlerFunc)
 	if handlerType.Kind() != reflect.Func {
 		return errorHandler(fmt.Errorf("handler kind %s is not %s", handlerType.Kind(), reflect.Func))
 	}
@@ -91,7 +94,7 @@ func newHandler(handlerSymbol interface{}) lambdaHandler {
 		return errorHandler(err)
 	}
 
-	return func(ctx context.Context, payload []byte) (interface{}, error) {
+	return lambdaHandler(func(ctx context.Context, payload []byte) (interface{}, error) {
 		// construct arguments
 		var args []reflect.Value
 		if takesContext {
@@ -123,5 +126,5 @@ func newHandler(handlerSymbol interface{}) lambdaHandler {
 		}
 
 		return val, err
-	}
+	})
 }

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -72,7 +72,7 @@ func TestInvalidHandlers(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
-			lambdaHandler := newHandler(testCase.handler)
+			lambdaHandler := NewHandler(testCase.handler)
 			_, err := lambdaHandler.Invoke(context.TODO(), make([]byte, 0))
 			assert.Equal(t, testCase.expected, err)
 		})
@@ -188,7 +188,7 @@ func TestInvokes(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
-			lambdaHandler := newHandler(testCase.handler)
+			lambdaHandler := NewHandler(testCase.handler)
 			response, err := lambdaHandler.Invoke(context.TODO(), []byte(testCase.input))
 			if testCase.expected.err != nil {
 				assert.Equal(t, testCase.expected.err, err)
@@ -201,7 +201,7 @@ func TestInvokes(t *testing.T) {
 }
 
 func TestInvalidJsonInput(t *testing.T) {
-	lambdaHandler := newHandler(func(s string) error { return nil })
+	lambdaHandler := NewHandler(func(s string) error { return nil })
 	_, err := lambdaHandler.Invoke(context.TODO(), []byte(`{"invalid json`))
 	assert.Equal(t, "unexpected end of JSON input", err.Error())
 


### PR DESCRIPTION
This change makes it much easier to write "middleware" for instrumentation, analytics, etc.

If the consumer registered their handler like this:
```go
func main() {
	lambda.Start(myHandler)
}
```
They may now use middleware like this:

```go
func addMiddleware(fn interface{}) lambda.Handler {
	h := lambda.NewHandler(fn)
	// h could easily be wrapped here to provide instrumentation here
	return h
}

func main() {
	lambda.StartHandler(addMiddleware(myHandler))
}
```

If `newHandler` is not public, writing middleware is real tough since the middleware layer must do reflection on the flexible `interface{}` function.

Thanks for your consideration!
