### PR TITLE
Add support for multi-value parameters in API Gateway proxy events

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -4,16 +4,18 @@ package events
 
 // APIGatewayProxyRequest contains data coming from the API Gateway proxy
 type APIGatewayProxyRequest struct {
-	Resource              string                        `json:"resource"` // The resource path defined in API Gateway
-	Path                  string                        `json:"path"`     // The url path for the caller
-	HTTPMethod            string                        `json:"httpMethod"`
-	Headers               map[string]string             `json:"headers"`
-	QueryStringParameters map[string]string             `json:"queryStringParameters"`
-	PathParameters        map[string]string             `json:"pathParameters"`
-	StageVariables        map[string]string             `json:"stageVariables"`
-	RequestContext        APIGatewayProxyRequestContext `json:"requestContext"`
-	Body                  string                        `json:"body"`
-	IsBase64Encoded       bool                          `json:"isBase64Encoded,omitempty"`
+	Resource                        string                        `json:"resource"` // The resource path defined in API Gateway
+	Path                            string                        `json:"path"`     // The url path for the caller
+	HTTPMethod                      string                        `json:"httpMethod"`
+	Headers                         map[string]string             `json:"headers"`
+	MultiValueHeaders               map[string][]string           `json:"multiValueHeaders"`
+	QueryStringParameters           map[string]string             `json:"queryStringParameters"`
+	MultiValueQueryStringParameters map[string][]string           `json:"multiValueQueryStringParameters"`
+	PathParameters                  map[string]string             `json:"pathParameters"`
+	StageVariables                  map[string]string             `json:"stageVariables"`
+	RequestContext                  APIGatewayProxyRequestContext `json:"requestContext"`
+	Body                            string                        `json:"body"`
+	IsBase64Encoded                 bool                          `json:"isBase64Encoded,omitempty"`
 }
 
 // APIGatewayProxyResponse configures the response to be returned by API Gateway for the request
@@ -45,6 +47,7 @@ type APIGatewayRequestIdentity struct {
 	CognitoIdentityID             string `json:"cognitoIdentityId"`
 	Caller                        string `json:"caller"`
 	APIKey                        string `json:"apiKey"`
+	AccessKey                     string `json:"accessKey"`
 	SourceIP                      string `json:"sourceIp"`
 	CognitoAuthenticationType     string `json:"cognitoAuthenticationType"`
 	CognitoAuthenticationProvider string `json:"cognitoAuthenticationProvider"`
@@ -90,16 +93,18 @@ type APIGatewayCustomAuthorizerRequest struct {
 
 // APIGatewayCustomAuthorizerRequestTypeRequest contains data coming in to a custom API Gateway authorizer function.
 type APIGatewayCustomAuthorizerRequestTypeRequest struct {
-	Type                  string                                              `json:"type"`
-	MethodArn             string                                              `json:"methodArn"`
-	Resource              string                                              `json:"resource"`
-	Path                  string                                              `json:"path"`
-	HTTPMethod            string                                              `json:"httpMethod"`
-	Headers               map[string]string                                   `json:"headers"`
-	QueryStringParameters map[string]string                                   `json:"queryStringParameters"`
-	PathParameters        map[string]string                                   `json:"pathParameters"`
-	StageVariables        map[string]string                                   `json:"stageVariables"`
-	RequestContext        APIGatewayCustomAuthorizerRequestTypeRequestContext `json:"requestContext"`
+	Type                            string                                              `json:"type"`
+	MethodArn                       string                                              `json:"methodArn"`
+	Resource                        string                                              `json:"resource"`
+	Path                            string                                              `json:"path"`
+	HTTPMethod                      string                                              `json:"httpMethod"`
+	Headers                         map[string]string                                   `json:"headers"`
+	MultiValueHeaders               map[string][]string                                 `json:"multiValueHeaders"`
+	QueryStringParameters           map[string]string                                   `json:"queryStringParameters"`
+	MultiValueQueryStringParameters map[string][]string                                 `json:"multiValueQueryStringParameters"`
+	PathParameters                  map[string]string                                   `json:"pathParameters"`
+	StageVariables                  map[string]string                                   `json:"stageVariables"`
+	RequestContext                  APIGatewayCustomAuthorizerRequestTypeRequestContext `json:"requestContext"`
 }
 
 // APIGatewayCustomAuthorizerResponse represents the expected format of an API Gateway authorization response.

--- a/events/testdata/apigw-custom-auth-request-type-request.json
+++ b/events/testdata/apigw-custom-auth-request-type-request.json
@@ -27,8 +27,34 @@
         "CloudFront-Is-Desktop-Viewer": "true",
         "Content-Type": "application/x-www-form-urlencoded"
     },
+    "multiValueHeaders": {
+        "X-AMZ-Date": ["20170718T062915Z"],
+        "Accept": ["*/*"],
+        "HeaderAuth1": ["headerValue1"],
+        "CloudFront-Viewer-Country": ["US"],
+        "CloudFront-Forwarded-Proto": ["https"],
+        "CloudFront-Is-Tablet-Viewer": ["false"],
+        "CloudFront-Is-Mobile-Viewer": ["false"],
+        "User-Agent": ["..."],
+        "X-Forwarded-Proto": ["https"],
+        "CloudFront-Is-SmartTV-Viewer": ["false"],
+        "Host": ["....execute-api.us-east-1.amazonaws.com"],
+        "Accept-Encoding": ["gzip, deflate"],
+        "X-Forwarded-Port": ["443"],
+        "X-Amzn-Trace-Id": ["..."],
+        "Via": ["...cloudfront.net (CloudFront)"],
+        "X-Amz-Cf-Id": ["..."],
+        "X-Forwarded-For": ["..., ..."],
+        "Postman-Token": ["..."],
+        "cache-control": ["no-cache"],
+        "CloudFront-Is-Desktop-Viewer": ["true"],
+        "Content-Type": ["application/x-www-form-urlencoded"]
+    },
     "queryStringParameters": {
         "QueryString1": "queryValue1"
+    },
+    "multiValueQueryStringParameters": {
+        "QueryString1": ["queryValue1"]
     },
     "pathParameters": {},
     "stageVariables": {

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -22,10 +22,34 @@
 		  "X-Forwarded-For": "54.240.196.186, 54.182.214.83",
 		  "X-Forwarded-Port": "443",
 		  "X-Forwarded-Proto": "https"
-	},
+    },
+    "multiValueHeaders": {
+        "Accept": ["*/*"],
+        "Accept-Encoding": ["gzip, deflate"],
+        "cache-control": ["no-cache"],
+        "CloudFront-Forwarded-Proto": ["https"],
+        "CloudFront-Is-Desktop-Viewer": ["true"],
+        "CloudFront-Is-Mobile-Viewer": ["false"],
+        "CloudFront-Is-SmartTV-Viewer": ["false"],
+        "CloudFront-Is-Tablet-Viewer": ["false"],
+        "CloudFront-Viewer-Country": ["US"],
+        "Content-Type": ["application/json"],
+        "headerName": ["headerValue"],
+        "Host": ["gy415nuibc.execute-api.us-east-1.amazonaws.com"],
+        "Postman-Token": ["9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f"],
+        "User-Agent": ["PostmanRuntime/2.4.5"],
+        "Via": ["1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)"],
+        "X-Amz-Cf-Id": ["pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A=="],
+        "X-Forwarded-For": ["54.240.196.186, 54.182.214.83"],
+        "X-Forwarded-Port": ["443"],
+        "X-Forwarded-Proto": ["https"]
+    },
 	"queryStringParameters": {
-		"name": "me"   
-	},
+		"name": "me"
+    },
+    "multiValueQueryStringParameters": {
+        "name": ["me"]
+    },
 	"pathParameters": {
 		"proxy": "hello/world"
 	},
@@ -42,7 +66,8 @@
 			"accountId": "theAccountId",
 			"cognitoIdentityId": "theCognitoIdentityId",
 			"caller": "theCaller",
-			"apiKey": "theApiKey",
+            "apiKey": "theApiKey",
+            "accessKey": "ANEXAMPLEOFACCESSKEY",
 			"sourceIp": "192.168.196.186",
 			"cognitoAuthenticationType": "theCognitoAuthenticationType",
 			"cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",


### PR DESCRIPTION
Recently I was digging more into Lambda environment and I found new fields which are not defined in `aws-lambda-go` struct for API Gateway Proxy Request event:

- `events.APIGatewayProxyRequest.MultiValueHeaders`.
- `events.APIGatewayProxyRequest.MultiValueQueryStringParameters`.
- `events.APIGatewayRequestIdentity.AccessKey` (populated whether doing an authorization using AWS credentials).

https://aws.amazon.com/about-aws/whats-new/2018/10/amazon-api-gateway-adds-support-for-multi-parameters/

Maintainers: do we need any extra unit test for these new fields?