### PR TITLE
Introduce HandlerTrace callbacks

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -98,7 +98,7 @@ func NewHandler(handlerFunc interface{}) Handler {
 
 	return lambdaHandler(func(ctx context.Context, payload []byte) (interface{}, error) {
 
-		trace := handlertrace.ContextHandlerTrace(ctx)
+		trace := handlertrace.FromContext(ctx)
 
 		// construct arguments
 		var args []reflect.Value

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -70,6 +70,42 @@ func validateReturns(handler reflect.Type) error {
 	return nil
 }
 
+// HandlerTrace allows handlers which wrap the return value of NewHandler to
+// access to the request and response events.
+type HandlerTrace struct {
+	RequestEvent  func(context.Context, interface{})
+	ResponseEvent func(context.Context, interface{})
+}
+
+func callbackCompose(f1, f2 func(context.Context, interface{})) func(context.Context, interface{}) {
+	return func(ctx context.Context, event interface{}) {
+		if nil != f1 {
+			f1(ctx, event)
+		}
+		if nil != f2 {
+			f2(ctx, event)
+		}
+	}
+}
+
+type handlerTraceKey struct{}
+
+// WithHandlerTrace adds callbacks to the provided context which allows handlers
+// which wrap the return value of NewHandler to access to the request and
+// response events.
+func WithHandlerTrace(ctx context.Context, trace HandlerTrace) context.Context {
+	existing := contextHandlerTrace(ctx)
+	return context.WithValue(ctx, handlerTraceKey{}, HandlerTrace{
+		RequestEvent:  callbackCompose(existing.RequestEvent, trace.RequestEvent),
+		ResponseEvent: callbackCompose(existing.ResponseEvent, trace.ResponseEvent),
+	})
+}
+
+func contextHandlerTrace(ctx context.Context) HandlerTrace {
+	trace, _ := ctx.Value(handlerTraceKey{}).(HandlerTrace)
+	return trace
+}
+
 // NewHandler creates a base lambda handler from the given handler function. The
 // returned Handler performs JSON deserialization and deserialization, and
 // delegates to the input handler function.  The handler function parameter must
@@ -95,6 +131,9 @@ func NewHandler(handlerFunc interface{}) Handler {
 	}
 
 	return lambdaHandler(func(ctx context.Context, payload []byte) (interface{}, error) {
+
+		trace := contextHandlerTrace(ctx)
+
 		// construct arguments
 		var args []reflect.Value
 		if takesContext {
@@ -107,7 +146,9 @@ func NewHandler(handlerFunc interface{}) Handler {
 			if err := json.Unmarshal(payload, event.Interface()); err != nil {
 				return nil, err
 			}
-
+			if nil != trace.RequestEvent {
+				trace.RequestEvent(ctx, event.Elem().Interface())
+			}
 			args = append(args, event.Elem())
 		}
 
@@ -123,6 +164,10 @@ func NewHandler(handlerFunc interface{}) Handler {
 		var val interface{}
 		if len(response) > 1 {
 			val = response[0].Interface()
+
+			if nil != trace.ResponseEvent {
+				trace.ResponseEvent(ctx, val)
+			}
 		}
 
 		return val, err

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-lambda-go/lambda/handlertrace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -227,20 +228,20 @@ func TestHandlerTrace(t *testing.T) {
 		}
 	}
 	ctx := context.Background()
-	ctx = WithHandlerTrace(ctx, HandlerTrace{}) // empty HandlerTrace
-	ctx = WithHandlerTrace(ctx, HandlerTrace{   // with RequestEvent
+	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
+	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{   // with RequestEvent
 		RequestEvent: func(c context.Context, e interface{}) {
 			requestHistory += "A"
 			checkInt(e, 123)
 		},
 	})
-	ctx = WithHandlerTrace(ctx, HandlerTrace{ // with ResponseEvent
+	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{ // with ResponseEvent
 		ResponseEvent: func(c context.Context, e interface{}) {
 			responseHistory += "X"
 			checkInt(e, 456)
 		},
 	})
-	ctx = WithHandlerTrace(ctx, HandlerTrace{ // with RequestEvent and ResponseEvent
+	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{ // with RequestEvent and ResponseEvent
 		RequestEvent: func(c context.Context, e interface{}) {
 			requestHistory += "B"
 			checkInt(e, 123)
@@ -250,7 +251,7 @@ func TestHandlerTrace(t *testing.T) {
 			checkInt(e, 456)
 		},
 	})
-	ctx = WithHandlerTrace(ctx, HandlerTrace{}) // empty HandlerTrace
+	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
 
 	payload := []byte(`123`)
 	js, err := handler.Invoke(ctx, payload)

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -228,20 +228,20 @@ func TestHandlerTrace(t *testing.T) {
 		}
 	}
 	ctx := context.Background()
-	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
-	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{   // with RequestEvent
+	ctx = handlertrace.NewContext(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
+	ctx = handlertrace.NewContext(ctx, handlertrace.HandlerTrace{   // with RequestEvent
 		RequestEvent: func(c context.Context, e interface{}) {
 			requestHistory += "A"
 			checkInt(e, 123)
 		},
 	})
-	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{ // with ResponseEvent
+	ctx = handlertrace.NewContext(ctx, handlertrace.HandlerTrace{ // with ResponseEvent
 		ResponseEvent: func(c context.Context, e interface{}) {
 			responseHistory += "X"
 			checkInt(e, 456)
 		},
 	})
-	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{ // with RequestEvent and ResponseEvent
+	ctx = handlertrace.NewContext(ctx, handlertrace.HandlerTrace{ // with RequestEvent and ResponseEvent
 		RequestEvent: func(c context.Context, e interface{}) {
 			requestHistory += "B"
 			checkInt(e, 123)
@@ -251,7 +251,7 @@ func TestHandlerTrace(t *testing.T) {
 			checkInt(e, 456)
 		},
 	})
-	ctx = handlertrace.WithHandlerTrace(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
+	ctx = handlertrace.NewContext(ctx, handlertrace.HandlerTrace{}) // empty HandlerTrace
 
 	payload := []byte(`123`)
 	js, err := handler.Invoke(ctx, payload)

--- a/lambda/handlertrace/trace.go
+++ b/lambda/handlertrace/trace.go
@@ -1,0 +1,45 @@
+// Package handlertrace allows middleware authors using lambda.NewHandler to
+// instrument request and response events.
+package handlertrace
+
+import (
+	"context"
+)
+
+// HandlerTrace allows handlers which wrap the return value of lambda.NewHandler
+// to access to the request and response events.
+type HandlerTrace struct {
+	RequestEvent  func(context.Context, interface{})
+	ResponseEvent func(context.Context, interface{})
+}
+
+func callbackCompose(f1, f2 func(context.Context, interface{})) func(context.Context, interface{}) {
+	return func(ctx context.Context, event interface{}) {
+		if nil != f1 {
+			f1(ctx, event)
+		}
+		if nil != f2 {
+			f2(ctx, event)
+		}
+	}
+}
+
+type handlerTraceKey struct{}
+
+// WithHandlerTrace adds callbacks to the provided context which allows handlers
+// which wrap the return value of lambda.NewHandler to access to the request and
+// response events.
+func WithHandlerTrace(ctx context.Context, trace HandlerTrace) context.Context {
+	existing := ContextHandlerTrace(ctx)
+	return context.WithValue(ctx, handlerTraceKey{}, HandlerTrace{
+		RequestEvent:  callbackCompose(existing.RequestEvent, trace.RequestEvent),
+		ResponseEvent: callbackCompose(existing.ResponseEvent, trace.ResponseEvent),
+	})
+}
+
+// ContextHandlerTrace returns the HandlerTrace associated with the provided
+// context.
+func ContextHandlerTrace(ctx context.Context) HandlerTrace {
+	trace, _ := ctx.Value(handlerTraceKey{}).(HandlerTrace)
+	return trace
+}

--- a/lambda/handlertrace/trace.go
+++ b/lambda/handlertrace/trace.go
@@ -26,20 +26,19 @@ func callbackCompose(f1, f2 func(context.Context, interface{})) func(context.Con
 
 type handlerTraceKey struct{}
 
-// WithHandlerTrace adds callbacks to the provided context which allows handlers
-// which wrap the return value of lambda.NewHandler to access to the request and
+// NewContext adds callbacks to the provided context which allows handlers which
+// wrap the return value of lambda.NewHandler to access to the request and
 // response events.
-func WithHandlerTrace(ctx context.Context, trace HandlerTrace) context.Context {
-	existing := ContextHandlerTrace(ctx)
+func NewContext(ctx context.Context, trace HandlerTrace) context.Context {
+	existing := FromContext(ctx)
 	return context.WithValue(ctx, handlerTraceKey{}, HandlerTrace{
 		RequestEvent:  callbackCompose(existing.RequestEvent, trace.RequestEvent),
 		ResponseEvent: callbackCompose(existing.ResponseEvent, trace.ResponseEvent),
 	})
 }
 
-// ContextHandlerTrace returns the HandlerTrace associated with the provided
-// context.
-func ContextHandlerTrace(ctx context.Context) HandlerTrace {
+// FromContext returns the HandlerTrace associated with the provided context.
+func FromContext(ctx context.Context) HandlerTrace {
 	trace, _ := ctx.Value(handlerTraceKey{}).(HandlerTrace)
 	return trace
 }


### PR DESCRIPTION
Hi

Now that `NewHandler` is public, it is possible to write "middleware" instrumentation that wraps the handler.  eg.  `lambda.Start(myHandler)`  becomes `lambda.StartHandler(addMiddleware(myHandler))`.  Fantastic!

Unfortunately, since the internal `lambdaHandler` does the JSON serialization and deserialization, the middleware doesn't have access to the request and response events. This is unfortunate because middleware instrumentation would really love to record request and response fields (such as the request event source ARN).

Consumers could be asked to modify their handlers to add callbacks, but it sure would be nice if the middleware could access the request and response automatically!!

Thinking through this problem, I was reminded of the [httptrace](https://golang.org/pkg/net/http/httptrace/) package which allows people to add http instrumentation by adding callbacks to the context. That's the idea presented here!

Example use:
```go
func myHandler(ctx context.Context, x int) (int, error) {
	return 456, nil
}

type handlerFunc func(ctx context.Context, payload []byte) ([]byte, error)

func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
	return h(ctx, payload)
}

// introduceMiddleware would exist in a third party package
func introduceMiddleware(originalHandler interface{}) lambda.Handler {
	handler := lambda.NewHandler(originalHandler)
	return handlerFunc(func(ctx context.Context, payload []byte) ([]byte, error) {
		ctx = lambda.WithHandlerTrace(ctx, lambda.HandlerTrace{
			RequestEvent: func(c context.Context, e interface{}) {
				fmt.Println("request", e)
			},
			ResponseEvent: func(c context.Context, e interface{}) {
				fmt.Println("response", e)
			},
		})
		return handler.Invoke(ctx, payload)
	})
}

func main() {
	lambda.StartHandler(introduceMiddleware(myHandler))
}
```

Thanks for your consideration!