### PR TITLE
Pass handler func []byte if the arg is interface{}

### DIFF
--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -4,6 +4,7 @@ package lambda
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -183,6 +184,19 @@ func TestInvokes(t *testing.T) {
 			expected: expected{`{"Number":9001}`, nil},
 			handler: func(event int) (struct{ Number int }, error) {
 				return struct{ Number int }{event}, nil
+			},
+		},
+		{
+			name:     "handler that accepts interface",
+			input:    `{"custom":9001}`,
+			expected: expected{`{"custom":9001}`, nil},
+			handler: func(i interface{}) (interface{}, error) {
+				assert.IsType(t, []byte{}, i)
+				c := struct {
+					Custom int `json:"custom"`
+				}{}
+				err := json.Unmarshal(i.([]byte), &c)
+				return c, err
 			},
 		},
 	}


### PR DESCRIPTION
When you pass a `func(ctx contex.Context, i interface{}) error{}` to `lambda.Start()` we
ran into this issue.  Since the wrapper took
`interface{}` as the second argument this would try to Unmarshal to it.

In `json.Unmarshal` if its an `interface{}` it unmarshals to
`map[string]interface`. But usually if its json you don't want a direct
transalation. For example `{"foo":"bar"}` turns into
`map[string]interface{}{"foo":"bar"}` even nesting all the way down.

This obviously changes the behavior (breaking even?) but we couldn't think of another way to let us get the raw `[]byte` back