### PR TITLE
Fix field name in AppSync example 

### DIFF
--- a/events/README_AppSync.md
+++ b/events/README_AppSync.md
@@ -17,7 +17,7 @@ import (
 func handler(ctx context.Context, event events.AppSyncResolverTemplate) error {
 
   fmt.Printf("Version: %s\n", event.Version)
-  fmt.Printf("Operation: %s\n", event.AppSyncOperation)
+  fmt.Printf("Operation: %s\n", event.Operation)
   fmt.Printf("Payload: %s\n", string(event.Payload))
 
 	return nil


### PR DESCRIPTION
Current `README_AppSync.md` file has wrong field name which causes `event.AppSyncOperation undefined (type events.AppSyncResolverTemplate has no field or method AppSyncOperation)` error when trying to run that sample code. The actual field name is `Operation` as seen in https://github.com/aws/aws-lambda-go/blob/master/events/appsync.go#L8.