### PR TITLE
Add multi-value headers to the API Gateway response

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -20,10 +20,11 @@ type APIGatewayProxyRequest struct {
 
 // APIGatewayProxyResponse configures the response to be returned by API Gateway for the request
 type APIGatewayProxyResponse struct {
-	StatusCode      int               `json:"statusCode"`
-	Headers         map[string]string `json:"headers"`
-	Body            string            `json:"body"`
-	IsBase64Encoded bool              `json:"isBase64Encoded,omitempty"`
+	StatusCode        int               `json:"statusCode"`
+	Headers           map[string]string `json:"headers"`
+	MultiValueHeaders map[string]string `json:"multiValueHeaders"`
+	Body              string            `json:"body"`
+	IsBase64Encoded   bool              `json:"isBase64Encoded,omitempty"`
 }
 
 // APIGatewayProxyRequestContext contains the information to identify the AWS account and resources invoking the

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -20,11 +20,11 @@ type APIGatewayProxyRequest struct {
 
 // APIGatewayProxyResponse configures the response to be returned by API Gateway for the request
 type APIGatewayProxyResponse struct {
-	StatusCode        int               `json:"statusCode"`
-	Headers           map[string]string `json:"headers"`
-	MultiValueHeaders map[string]string `json:"multiValueHeaders"`
-	Body              string            `json:"body"`
-	IsBase64Encoded   bool              `json:"isBase64Encoded,omitempty"`
+	StatusCode        int                 `json:"statusCode"`
+	Headers           map[string]string   `json:"headers"`
+	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	Body              string              `json:"body"`
+	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 }
 
 // APIGatewayProxyRequestContext contains the information to identify the AWS account and resources invoking the

--- a/events/testdata/apigw-response.json
+++ b/events/testdata/apigw-response.json
@@ -19,5 +19,24 @@
      "X-Forwarded-Port": "443",
      "X-Forwarded-Proto": "https"
    },
+   "multiValueHeaders": {
+    "Accept": ["text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"],
+    "Accept-Encoding": ["gzip, deflate, lzma, sdch, br"],
+    "Accept-Language": ["en-US,en;q=0.8"],
+    "CloudFront-Forwarded-Proto": ["https"],
+    "CloudFront-Is-Desktop-Viewer": ["true"],
+    "CloudFront-Is-Mobile-Viewer": ["false"],
+    "CloudFront-Is-SmartTV-Viewer": ["false"],
+    "CloudFront-Is-Tablet-Viewer": ["false"],
+    "CloudFront-Viewer-Country": ["US"],
+    "Host": ["wt6mne2s9k.execute-api.us-west-2.amazonaws.com"],
+    "Upgrade-Insecure-Requests": ["1"],
+    "User-Agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48"],
+    "Via": ["1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)"],
+    "X-Amz-Cf-Id": ["nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g=="],
+    "X-Forwarded-For": ["192.168.100.1, 192.168.1.1"],
+    "X-Forwarded-Port": ["443"],
+    "X-Forwarded-Proto": ["https"]
+  },
    "body": "Hello World"
  }


### PR DESCRIPTION
I noticed `multiValueHeaders` is missing in the API Gateway response event.

- Relates to #136.
- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format