### PR TITLE
add a CustomData field to the CodeCommitRecord structure.

### DIFF
--- a/events/code_commit.go
+++ b/events/code_commit.go
@@ -58,6 +58,7 @@ type CodeCommitRecord struct {
 	EventSource          string               `json:"eventSource"`
 	AWSRegion            string               `json:"awsRegion"`
 	EventTotalParts      uint64               `json:"eventTotalParts"`
+	CustomData           string               `json:"customData,omitempty"`
 }
 
 // String returns a string representation of this object.
@@ -67,11 +68,11 @@ func (r CodeCommitRecord) String() string {
 		"{eventId: %v, eventVersion: %v, eventTime: %v, eventTriggerName: %v, "+
 			"eventPartNumber: %v, codeCommit: %v, eventName: %v, "+
 			"eventTriggerConfigId: %v, eventSourceARN: %v, userIdentityARN: %v, "+
-			"eventSource: %v, awsRegion: %v, eventTotalParts: %v}",
+			"eventSource: %v, awsRegion: %v, eventTotalParts: %v, customData: %v}",
 		r.EventID, r.EventVersion, r.EventTime, r.EventTriggerName,
 		r.EventPartNumber, r.CodeCommit, r.EventName,
 		r.EventTriggerConfigId, r.EventSourceARN, r.UserIdentityARN,
-		r.EventSource, r.AWSRegion, r.EventTotalParts)
+		r.EventSource, r.AWSRegion, r.EventTotalParts, r.CustomData)
 }
 
 // CodeCommitCodeCommit represents a CodeCommit object in a record

--- a/events/code_commit_test.go
+++ b/events/code_commit_test.go
@@ -102,6 +102,29 @@ func TestCodeCommitRecord(t *testing.T) {
         }
       `),
 		},
+		{
+			Name: "CodeCommitRecord",
+			Input: []byte(`
+        {
+          "eventId": "5a824061-17ca-46a9-bbf9-114edeadbeee",
+          "eventVersion": "1.0",
+          "eventTime": "2018-01-22T15:58:33.475+0000",
+          "eventTriggerName": "my-trigger",
+          "eventPartNumber": 1,
+          "codecommit": {
+            "references": []
+          },
+          "eventName": "TriggerEventTest",
+          "eventTriggerConfigId": "5a824061-17ca-46a9-bbf9-114edeadbeef",
+          "eventSourceARN": "arn:aws:codecommit:us-east-1:123456789012:my-repo",
+          "userIdentityARN": "arn:aws:iam::123456789012:root",
+          "eventSource": "aws:codecommit",
+          "awsRegion": "us-east-1",
+          "eventTotalParts": 1,
+		  "customData": "custom data"
+        }
+      `),
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Triggers from CodeCommit may have a "customData" field. they are delivered to a lambda function as part of a CodeCommit record.

https://docs.aws.amazon.com/codecommit/latest/APIReference/API_RepositoryTrigger.html
https://docs.aws.amazon.com/codecommit/latest/userguide/how-to-notify-lambda.html 