### PR TITLE
Add S3 test event

### DIFF
--- a/events/s3.go
+++ b/events/s3.go
@@ -51,3 +51,11 @@ type S3Object struct {
 	ETag          string `json:"eTag"`
 	Sequencer     string `json:"sequencer"`
 }
+
+type S3TestEvent struct {
+	Service   string    `json:"Service"`
+	Event     string    `json:"Event"`
+	Time      time.Time `json:"Time"`
+	RequestID string    `json:"RequestId"`
+	HostID    string    `json:"HostId"`
+}

--- a/events/s3.go
+++ b/events/s3.go
@@ -54,6 +54,7 @@ type S3Object struct {
 
 type S3TestEvent struct {
 	Service   string    `json:"Service"`
+	Bucket    string    `json:"Bucket"`
 	Event     string    `json:"Event"`
 	Time      time.Time `json:"Time"`
 	RequestID string    `json:"RequestId"`

--- a/events/s3_test.go
+++ b/events/s3_test.go
@@ -30,7 +30,7 @@ func TestS3EventMarshaling(t *testing.T) {
 	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
-func TestS3TestEventMarchaling(t *testing.T) {
+func TestS3TestEventMarshaling(t *testing.T) {
 	inputJSON := []byte(`{
 	    "Service" :"Amazon S3",
 	    "Event": "s3:TestEvent",

--- a/events/s3_test.go
+++ b/events/s3_test.go
@@ -12,24 +12,44 @@ import (
 func TestS3EventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := readJsonFromFile(t, "./testdata/s3-event.json")
+	inputJSON := readJsonFromFile(t, "./testdata/s3-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent S3Event
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
-func TestS3MarshalingMalformedJson(t *testing.T) {
+func TestS3TestEventMarchaling(t *testing.T) {
+	inputJSON := []byte(`{
+	    "Service" :"Amazon S3",
+	    "Event": "s3:TestEvent",
+	    "Time": "2019-02-04T19:34:46.985Z",
+	    "Bucket": "bmoffatt",
+	    "RequestId": "7BA1940DC6AF888B",
+	    "HostId": "q1YDbiaMjllP0m+Lcy6cKKgxNrMLFJ9zCrZUFBqHGTG++0nXvnTDIGC7q2/QPAsJg86E8gI7y9U="
+	}`)
+	var inputEvent S3TestEvent
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestS3MarshalingMalformedJSON(t *testing.T) {
 	test.TestMalformedJson(t, S3Event{})
 }


### PR DESCRIPTION
As seen in https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html.

I didn't write a test as they are set up for a 1-1 mapping between event and service. Happy to add one, but it will take some test refactoring and for this simple struct that is never used in production I thought it likely wasn't worth it.