### PR TITLE
Add Kinesis Stream Metadata to firehose event

### DIFF
--- a/events/firehose.go
+++ b/events/firehose.go
@@ -4,10 +4,11 @@ package events
 
 // KinesisFirehoseEvent represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
 type KinesisFirehoseEvent struct {
-	InvocationID      string                       `json:"invocationId"`
-	DeliveryStreamArn string                       `json:"deliveryStreamArn"`
-	Region            string                       `json:"region"`
-	Records           []KinesisFirehoseEventRecord `json:"records"`
+	InvocationID           string                       `json:"invocationId"`
+	DeliveryStreamArn      string                       `json:"deliveryStreamArn"`
+	SourceKinesisStreamArn string                       `json:"sourceKinesisStreamArn"`
+	Region                 string                       `json:"region"`
+	Records                []KinesisFirehoseEventRecord `json:"records"`
 }
 
 type KinesisFirehoseEventRecord struct {

--- a/events/firehose.go
+++ b/events/firehose.go
@@ -12,9 +12,10 @@ type KinesisFirehoseEvent struct {
 }
 
 type KinesisFirehoseEventRecord struct {
-	RecordID                    string                `json:"recordId"`
-	ApproximateArrivalTimestamp MilliSecondsEpochTime `json:"approximateArrivalTimestamp"`
-	Data                        []byte                `json:"data"`
+	RecordID                      string                        `json:"recordId"`
+	ApproximateArrivalTimestamp   MilliSecondsEpochTime         `json:"approximateArrivalTimestamp"`
+	Data                          []byte                        `json:"data"`
+	KinesisFirehoseRecordMetadata KinesisFirehoseRecordMetadata `json:"kinesisRecordMetadata"`
 }
 
 // Constants used for describing the transformation result
@@ -32,4 +33,11 @@ type KinesisFirehoseResponseRecord struct {
 	RecordID string `json:"recordId"`
 	Result   string `json:"result"` // The status of the transformation. May be TransformedStateOk, TransformedStateDropped or TransformedStateProcessingFailed
 	Data     []byte `json:"data"`
+}
+
+type KinesisFirehoseRecordMetadata struct {
+	ShardID                     string                `json:"shardId"`
+	PartitionKey                string                `json:"partitionKey"`
+	SequenceNumber              string                `json:"sequenceNumber"`
+	ApproximateArrivalTimestamp MilliSecondsEpochTime `json:"approximateArrivalTimestamp"`
 }

--- a/events/testdata/kinesis-firehose-event.json
+++ b/events/testdata/kinesis-firehose-event.json
@@ -11,7 +11,7 @@
        "kinesisRecordMetadata": {
          "shardId": "shardId-000000000000",
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c317a",
-         "approximateArrivalTimestamp": "1507217624302",
+         "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785154",
          "subsequenceNumber": ""
        }
@@ -23,7 +23,7 @@
        "kinesisRecordMetadata": {
          "shardId": "shardId-000000000001",
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c318a",
-         "approximateArrivalTimestamp": "1507217624302",
+         "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785155",
          "subsequenceNumber": ""
        }

--- a/events/testdata/kinesis-firehose-event.json
+++ b/events/testdata/kinesis-firehose-event.json
@@ -1,6 +1,7 @@
 {
    "invocationId": "invoked123",
    "deliveryStreamArn": "aws:lambda:events",
+   "sourceKinesisStreamArn": "arn:aws:kinesis:us-east-1:123456789012:stream/test",
    "region": "us-west-2",
    "records": [
      {


### PR DESCRIPTION
Add sourceKinesisStreamArn and KinesisRecordMetadata to event structs .

Attempting to do a put record API call on a Firehose Delivery stream which has a Kinesis Stream as the source will result in the error `This operation is not permitted on KinesisStreamAsSource delivery stream type.`. Therefore it is useful to have the sourceKinesisStreamArn so put record API calls can be made by Lambda functions to the source Kinesis Stream. 

In addition the Kinesis Record Metadata has been added to the event so the same partition key can be used if the data needs to be reingest to the source Kinesis stream.

This is particularly useful when attempting to reingest data due to hitting the 6MB size limit of the response payload.

