### PR TITLE
Add go module support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
 matrix:
   allow_failures:
     - go: tip
+    - go: 1.12
+      env: GO111MODULE=on
   fast_finish: true
 
 notifications:
@@ -34,3 +36,14 @@ script:
   
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+jobs:
+  include:
+    - stage: "Go Module"
+      go: 1.12
+      env: GO111MODULE=on
+      before_install:
+        - go mod download
+      install:
+        - go get golang.org/x/lint/golint
+        - go get github.com/haya14busa/goverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ install:
   - go get github.com/haya14busa/goverage
 
 matrix:
+  include:
+    - go: 1.12
+      env: GO111MODULE=on
+      before_install:
+        - go mod download
+      install:
+        - go get golang.org/x/lint/golint
+        - go get github.com/haya14busa/goverage
   allow_failures:
     - go: tip
     - go: 1.12
@@ -36,14 +44,3 @@ script:
   
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-jobs:
-  include:
-    - stage: "Go Module"
-      go: 1.12
-      env: GO111MODULE=on
-      before_install:
-        - go mod download
-      install:
-        - go get golang.org/x/lint/golint
-        - go get github.com/haya14busa/goverage

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/bhavikkumar/aws-lambda-go
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.0
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/aws/aws-lambda-go v1.10.0
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.1
 	gopkg.in/urfave/cli.v1 v1.20.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/bhavikkumar/aws-lambda-go
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.2.1
+	gopkg.in/urfave/cli.v1 v1.20.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/bhavikkumar/aws-lambda-go
+module github.com/aws/aws-lambda-go
 
 go 1.12
 
 require (
-	github.com/aws/aws-lambda-go v1.10.0
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-lambda-go v1.10.0 h1:uafgdfYGQD0UeT7d2uKdyWW8j/ZYRifRPIdmeqLzLCk=
-github.com/aws/aws-lambda-go v1.10.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
+github.com/aws/aws-lambda-go v1.10.0 h1:uafgdfYGQD0UeT7d2uKdyWW8j/ZYRifRPIdmeqLzLCk=
+github.com/aws/aws-lambda-go v1.10.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.1 h1:52QO5WkIUcHGIR7EnGagH88x1bUzqGXTC5/1bDTUQ7U=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=

--- a/lambda/panic_test.go
+++ b/lambda/panic_test.go
@@ -113,7 +113,7 @@ func testRuntimeStackTrace(t *testing.T) {
 
 	frame := panicInfo.StackTrace[0]
 
-	assert.Equal(t, frame.Path, packagePath+"/panic_test.go")
+	assert.Equal(t, packagePath+"/panic_test.go", frame.Path)
 	assert.True(t, frame.Line > 0)
 	assert.Equal(t, "testRuntimeStackTrace", frame.Label)
 }

--- a/lambda/panic_test.go
+++ b/lambda/panic_test.go
@@ -112,33 +112,28 @@ func testRuntimeStackTrace(t *testing.T) {
 	assert.NoError(t, err)
 
 	frame := panicInfo.StackTrace[0]
-	framePaths := strings.Split(frame.Path, "/")
 
-	// The frame.Path will only contain the last 5 directories if there are more than 5 directories.
-	if len(packagePath) >= 5 {
-		packagePath = packagePath[len(packagePath)-4:]
-	}
-	packagePath = append(packagePath, "panic_test.go")
-
-	assert.Len(t, framePaths, len(packagePath))
-	for i := range framePaths {
-		assert.Equal(t, framePaths[i], packagePath[i])
-	}
-	assert.ElementsMatch(t, framePaths, packagePath)
+	assert.Equal(t, frame.Path, packagePath+"/panic_test.go")
 	assert.True(t, frame.Line > 0)
 	assert.Equal(t, "testRuntimeStackTrace", frame.Label)
 }
 
-func getPackagePath() (paths []string, err error) {
+func getPackagePath() (string, error) {
 	fullPath, err := os.Getwd()
 	if err != nil {
-		return
+		return "", err
 	}
 
+	var paths []string
 	if runtime.GOOS == "windows" {
 		paths = strings.Split(fullPath, "\\")
 	} else {
 		paths = strings.Split(fullPath, "/")
 	}
-	return
+
+	// The frame.Path will only contain the last 5 directories if there are more than 5 directories.
+	if len(paths) >= 5 {
+		paths = paths[len(paths)-4:]
+	}
+	return strings.Join(paths, "/"), nil
 }

--- a/lambda/panic_test.go
+++ b/lambda/panic_test.go
@@ -111,15 +111,19 @@ func testRuntimeStackTrace(t *testing.T) {
 	packagePath, err := getPackagePath()
 	assert.NoError(t, err)
 
-	// The frame.Path will only contain the last 5 directories
+	frame := panicInfo.StackTrace[0]
+	framePaths := strings.Split(frame.Path, "/")
+
+	// The frame.Path will only contain the last 5 directories if there are more than 5 directories.
 	if len(packagePath) >= 5 {
 		packagePath = packagePath[len(packagePath)-4:]
 	}
 	packagePath = append(packagePath, "panic_test.go")
 
-	frame := panicInfo.StackTrace[0]
-	framePaths := strings.Split(frame.Path, "/")
-
+	assert.Len(t, framePaths, len(packagePath))
+	for i := range framePaths {
+		assert.Equal(t, framePaths[i], packagePath[i])
+	}
 	assert.ElementsMatch(t, framePaths, packagePath)
 	assert.True(t, frame.Line > 0)
 	assert.Equal(t, "testRuntimeStackTrace", frame.Label)


### PR DESCRIPTION
This resolves #181 

Initialized go modules from go deps. Modified the testRuntimeStackTrace test to compare slice of the package path instead of the raw string. as only the last 5 packages/directories are returned from frame.path.

Modified the Travis-CI job to have a job which sets GO111MODULE to on and overrides the before_install and install step to use `go mod download` instead of `dep ensure`. All other steps are kept the same. See https://travis-ci.com/bhavikkumar/aws-lambda-go/builds/111472734
