### PR TITLE
Enable function to be created outside of StartHandler.

### DIFF
--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -53,9 +53,7 @@ func StartHandler(handler Handler) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	function := new(Function)
-	function.handler = handler
-	err = rpc.Register(function)
+	err = rpc.Register(NewFunction(handler))
 	if err != nil {
 		log.Fatal("failed to register handler function")
 	}

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -16,6 +16,10 @@ type Function struct {
 	handler Handler
 }
 
+func NewFunction(handler Handler) *Function {
+	return &Function{handler: handler}
+}
+
 func (fn *Function) Ping(req *messages.PingRequest, response *messages.PingResponse) error {
 	*response = messages.PingResponse{}
 	return nil


### PR DESCRIPTION
Function is useless outside of the lambda package as there is no way to create a function with a non-nil handler. I have need to, for example, change the error conditions from log.Fatal within the entrypoint, but not having access to a Function constructor stops me from writing a reasonable replacement in my application code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
