### PR TITLE
Update LexResponse according to example and documentation.

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -47,7 +47,7 @@ type Slots map[string]*string
 
 type LexResponse struct {
 	SessionAttributes SessionAttributes `json:"sessionAttributes,omitempty"`
-	DialogAction      *LexDialogAction  `json:"dialogAction,omitempty"`
+	DialogAction      LexDialogAction   `json:"dialogAction,omitempty"`
 }
 
 type LexResponseCard struct {


### PR DESCRIPTION
*Based on issue #197*

Due to official documentation here: https://docs.aws.amazon.com/lex/latest/dg/lambda-input-response-format.html#using-lambda-response-format `dialogAction` field has to be required. Also, with implemented struct example in `README_Lex.md` will cause an error. 

I have updated `DialogAction` parameter in `LexResponse` struct according to example and documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
