### PR TITLE
Minimum working configuration

### DIFF
--- a/events/README_ALBTargetGroupEvents.md
+++ b/events/README_ALBTargetGroupEvents.md
@@ -29,7 +29,7 @@ func handleRequest(ctx context.Context, request events.ALBTargetGroupRequest) (e
 		fmt.Printf("    %s: %s\n", key, value)
 	}
 
-	return events.ALBTargetGroupResponse{Body: request.Body, StatusCode: 200, StatusDescription: "200 OK", IsBase64Encoded: false}, nil
+	return events.ALBTargetGroupResponse{Body: request.Body, StatusCode: 200, StatusDescription: "200 OK", IsBase64Encoded: false, Headers: map[string]string{}}}, nil
 }
 
 func main() {


### PR DESCRIPTION
*Issue #, if available:*
The example given will return a 502 Bad Gateway

*Description of changes:*

Adding an empty header will make the ALB respond successfully.

Alternatively, using text/plain content type will return the body as plain text.
```
map[string]string{"Content-Type":"text/plain"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
