### PR TITLE
Add event types for Cognito PreAuthentication Lambda trigger

### DIFF
--- a/events/README_Cognito_UserPools_PreAuthentication.md
+++ b/events/README_Cognito_UserPools_PreAuthentication.md
@@ -1,0 +1,25 @@
+# Sample Function
+
+The following is a sample Lambda function that receives Amazon Cognito User Pools pre-authentication event as an input and writes some of the record data to CloudWatch Logs. (Note that by default anything written to Console will be logged as CloudWatch Logs events.)
+
+Please see instructions for setting up the Cognito triggers at https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html .
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/aws/aws-lambda-go/lambda"
+    "github.com/aws/aws-lambda-go/events"
+)
+
+func handler(event events.CognitoEventUserPoolsPreAuthentication) (events.CognitoEventUserPoolsPreAuthentication, error) {
+    fmt.Printf("PreAuthentication of user: %s\n", event.UserName)
+    return event, nil
+}
+
+func main() {
+  lambda.Start(handler)
+}
+```

--- a/events/cognito.go
+++ b/events/cognito.go
@@ -28,6 +28,14 @@ type CognitoEventUserPoolsPreSignup struct {
 	Response CognitoEventUserPoolsPreSignupResponse `json:"response"`
 }
 
+// CognitoEventUserPoolsPreAuthentication is sent by AWS Cognito User Pools when a user submits their information
+// to be authenticated, allowing you to perform custom validations to accept or deny the sign in request.
+type CognitoEventUserPoolsPreAuthentication struct {
+	CognitoEventUserPoolsHeader
+	Request  CognitoEventUserPoolsPreAuthenticationRequest  `json:"request"`
+	Response CognitoEventUserPoolsPreAuthenticationResponse `json:"response"`
+}
+
 // CognitoEventUserPoolsPostConfirmation is sent by AWS Cognito User Pools after a user is confirmed,
 // allowing the Lambda to send custom messages or add custom logic.
 type CognitoEventUserPoolsPostConfirmation struct {
@@ -87,6 +95,16 @@ type CognitoEventUserPoolsPreSignupResponse struct {
 	AutoConfirmUser bool `json:"autoConfirmUser"`
 	AutoVerifyEmail bool `json:"autoVerifyEmail"`
 	AutoVerifyPhone bool `json:"autoVerifyPhone"`
+}
+
+// CognitoEventUserPoolsPreAuthenticationRequest contains the request portion of a PreAuthentication event
+type CognitoEventUserPoolsPreAuthenticationRequest struct {
+	UserAttributes map[string]string `json:"userAttributes"`
+	ValidationData map[string]string `json:"validationData"`
+}
+
+// CognitoEventUserPoolsPreAuthenticationResponse contains the response portion of a PreAuthentication event
+type CognitoEventUserPoolsPreAuthenticationResponse struct {
 }
 
 // CognitoEventUserPoolsPostConfirmationRequest contains the request portion of a PostConfirmation event

--- a/events/cognito_test.go
+++ b/events/cognito_test.go
@@ -64,6 +64,33 @@ func TestCognitoUserPoolsPreSignupMarshalingMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, CognitoEventUserPoolsPreSignup{})
 }
 
+func TestCognitoEventUserPoolsPreAuthenticationMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-presignup.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into CognitoEvent
+	var inputEvent CognitoEventUserPoolsPreAuthentication
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestCognitoUserPoolsPreAuthenticationMarshalingMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, CognitoEventUserPoolsPreAuthentication{})
+}
+
 func TestCognitoEventUserPoolsPostConfirmationMarshaling(t *testing.T) {
 
 	// read json from file

--- a/events/cognito_test.go
+++ b/events/cognito_test.go
@@ -67,7 +67,7 @@ func TestCognitoUserPoolsPreSignupMarshalingMalformedJson(t *testing.T) {
 func TestCognitoEventUserPoolsPreAuthenticationMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-presignup.json")
+	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-preauthentication.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/testdata/cognito-event-userpools-preauthentication.json
+++ b/events/testdata/cognito-event-userpools-preauthentication.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "triggerSource": "PreAuthentication_Authentication",
+  "region": "<region>",
+  "userPoolId": "<userPoolId>",
+  "userName": "<userName>",
+  "callerContext": {
+      "awsSdkVersion": "<calling aws sdk with version>",
+      "clientId": "<apps client id>"
+  },
+  "request": {
+      "userAttributes": {
+          "email": "<email>"
+       },
+      "validationData": {
+          "k1": "v1",
+          "k2": "v2"
+       }
+  },
+  "response": {}
+}


### PR DESCRIPTION
Adds the following Cognito event types:

- `events.CognitoEventUserPoolsPreAuthentication`
- `events.CognitoEventUserPoolsPreAuthenticationRequest`
- `events.CognitoEventUserPoolsPreAuthenticationResponse`

Added tests are based on existing Cognito tests sourced from this repository (specifically: TestCognitoEventUserPoolsPreSignupMarshaling and TestCognitoUserPoolsPreSignupMarshalingMalformedJson). 

Parameters conform to AWS documentation for Cognito PreAuthentication: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-authentication.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.