### PR TITLE
[add] Add fields to CognitoEventUserPoolsPostConfirmationResponse

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -96,6 +96,9 @@ type CognitoEventUserPoolsPostConfirmationRequest struct {
 
 // CognitoEventUserPoolsPostConfirmationResponse contains the response portion of a PostConfirmation event
 type CognitoEventUserPoolsPostConfirmationResponse struct {
+	EmailMessage string `json:"emailMessage"`
+	EmailSubject string `json:"emailSubject"`
+	SmsMessage   string `json:"smsMessage"`
 }
 
 // CognitoEventUserPoolsPreTokenGenRequest contains request portion of PreTokenGen event

--- a/events/cognito.go
+++ b/events/cognito.go
@@ -98,7 +98,7 @@ type CognitoEventUserPoolsPostConfirmationRequest struct {
 type CognitoEventUserPoolsPostConfirmationResponse struct {
 	EmailMessage string `json:"emailMessage"`
 	EmailSubject string `json:"emailSubject"`
-	SmsMessage   string `json:"smsMessage"`
+	SMSMessage   string `json:"smsMessage"`
 }
 
 // CognitoEventUserPoolsPreTokenGenRequest contains request portion of PreTokenGen event

--- a/events/testdata/cognito-event-userpools-postconfirmation.json
+++ b/events/testdata/cognito-event-userpools-postconfirmation.json
@@ -14,5 +14,9 @@
           "phone_number": "<phone_number>"
       }
   },
-  "response": {}
+  "response": {
+    "emailMessage": "<emailMessage>",
+    "emailSubject": "<emailSubject>",
+    "smsMessage": "<smsMessage>"
+  }
 }


### PR DESCRIPTION
### Sorry. please read it first:
This pull request is equivalent to #183 but an exam has been added.
This change is something that I want to be included as soon as possible.

If there is no problem, I would like you to accept this pull request. 🙇 

### Issue #, if available:
Can not change the subject, message and sms message sent in a custom response.

### Description of changes:
Add a field to `CognitoEventUserPoolsPostConfirmationResponse` class
This is useful for changing the text and subject and sms message send in a custom response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.