### PR TITLE
Add usernameParameter to CognitoEventUserPoolsCustomMessageRequest

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -226,8 +226,9 @@ type CognitoEventUserPoolsCustomMessage struct {
 
 // CognitoEventUserPoolsCustomMessageRequest contains the request portion of a CustomMessage event
 type CognitoEventUserPoolsCustomMessageRequest struct {
-	UserAttributes map[string]interface{} `json:"userAttributes"`
-	CodeParameter  string                 `json:"codeParameter"`
+	UserAttributes    map[string]interface{} `json:"userAttributes"`
+	CodeParameter     string                 `json:"codeParameter"`
+	UsernameParameter string                 `json:"usernameParameter"`
 }
 
 // CognitoEventUserPoolsCustomMessageResponse contains the response portion of a CustomMessage event

--- a/events/testdata/cognito-event-userpools-custommessage.json
+++ b/events/testdata/cognito-event-userpools-custommessage.json
@@ -13,7 +13,8 @@
           "phone_number_verified": true,
           "email_verified": false
        },
-      "codeParameter": "####"
+      "codeParameter": "####",
+      "usernameParameter": "{username}"
   },
   "response": {
       "smsMessage": "<custom message to be sent in the message with code parameter>",


### PR DESCRIPTION
*Issue #, if available:*
I did not open an issue for this because the fix is quick.

*Description of changes:*
The CustomMessage_AdminCreateUser trigger returns a user name and verification code, so the request must include both request.usernameParameter and request.codeParameter. Add the usernameParameter field to the CognitoEventUserPoolsCustomMessageRequest struct to meet this requirement.

https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.