### PR TITLE
Adds OperationName to API Gateway Proxy Request

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -30,15 +30,16 @@ type APIGatewayProxyResponse struct {
 // APIGatewayProxyRequestContext contains the information to identify the AWS account and resources invoking the
 // Lambda function. It also includes Cognito identity information for the caller.
 type APIGatewayProxyRequestContext struct {
-	AccountID    string                    `json:"accountId"`
-	ResourceID   string                    `json:"resourceId"`
-	Stage        string                    `json:"stage"`
-	RequestID    string                    `json:"requestId"`
-	Identity     APIGatewayRequestIdentity `json:"identity"`
-	ResourcePath string                    `json:"resourcePath"`
-	Authorizer   map[string]interface{}    `json:"authorizer"`
-	HTTPMethod   string                    `json:"httpMethod"`
-	APIID        string                    `json:"apiId"` // The API Gateway rest API Id
+	AccountID     string                    `json:"accountId"`
+	ResourceID    string                    `json:"resourceId"`
+	OperationName string                    `json:"operationName,omitempty"`
+	Stage         string                    `json:"stage"`
+	RequestID     string                    `json:"requestId"`
+	Identity      APIGatewayRequestIdentity `json:"identity"`
+	ResourcePath  string                    `json:"resourcePath"`
+	Authorizer    map[string]interface{}    `json:"authorizer"`
+	HTTPMethod    string                    `json:"httpMethod"`
+	APIID         string                    `json:"apiId"` // The API Gateway rest API Id
 }
 
 // APIGatewayRequestIdentity contains identity information for the request caller.

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -180,3 +180,32 @@ func TestApiGatewayCustomAuthorizerResponseMarshaling(t *testing.T) {
 func TestApiGatewayCustomAuthorizerResponseMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, APIGatewayCustomAuthorizerResponse{})
 }
+
+func TestApiGatewayRestApiOpenApiRequestMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/apigw-restapi-openapi-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent APIGatewayProxyRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// validate request context
+	requestContext := inputEvent.RequestContext
+	if requestContext.OperationName != "HelloWorld" {
+		t.Errorf("could not extract operationName from context: %v", requestContext)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}

--- a/events/testdata/apigw-restapi-openapi-request.json
+++ b/events/testdata/apigw-restapi-openapi-request.json
@@ -1,0 +1,89 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/hello/world",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept": "*/*",
+    "Accept-Encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "headerName": "headerValue",
+    "Host": "gy415nuibc.execute-api.us-east-1.amazonaws.com",
+    "Postman-Token": "9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f",
+    "User-Agent": "PostmanRuntime/2.4.5",
+    "Via": "1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A==",
+    "X-Forwarded-For": "54.240.196.186, 54.182.214.83",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": ["*/*"],
+    "Accept-Encoding": ["gzip, deflate"],
+    "cache-control": ["no-cache"],
+    "CloudFront-Forwarded-Proto": ["https"],
+    "CloudFront-Is-Desktop-Viewer": ["true"],
+    "CloudFront-Is-Mobile-Viewer": ["false"],
+    "CloudFront-Is-SmartTV-Viewer": ["false"],
+    "CloudFront-Is-Tablet-Viewer": ["false"],
+    "CloudFront-Viewer-Country": ["US"],
+    "Content-Type": ["application/json"],
+    "headerName": ["headerValue"],
+    "Host": ["gy415nuibc.execute-api.us-east-1.amazonaws.com"],
+    "Postman-Token": ["9f583ef0-ed83-4a38-aef3-eb9ce3f7a57f"],
+    "User-Agent": ["PostmanRuntime/2.4.5"],
+    "Via": ["1.1 d98420743a69852491bbdea73f7680bd.cloudfront.net (CloudFront)"],
+    "X-Amz-Cf-Id": ["pn-PWIJc6thYnZm5P0NMgOUglL1DYtl0gdeJky8tqsg8iS_sgsKD1A=="],
+    "X-Forwarded-For": ["54.240.196.186, 54.182.214.83"],
+    "X-Forwarded-Port": ["443"],
+    "X-Forwarded-Proto": ["https"]
+  },
+  "queryStringParameters": {
+    "name": "me"
+  },
+  "multiValueQueryStringParameters": {
+    "name": ["me"]
+  },
+  "pathParameters": {
+    "proxy": "hello/world"
+  },
+  "stageVariables": {
+    "stageVariableName": "stageVariableValue"
+  },
+  "requestContext": {
+    "accountId": "12345678912",
+    "resourceId": "roq9wj",
+    "operationName": "HelloWorld",
+    "stage": "testStage",
+    "requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
+    "identity": {
+      "cognitoIdentityPoolId": "theCognitoIdentityPoolId",
+      "accountId": "theAccountId",
+      "cognitoIdentityId": "theCognitoIdentityId",
+      "caller": "theCaller",
+      "apiKey": "theApiKey",
+      "accessKey": "ANEXAMPLEOFACCESSKEY",
+      "sourceIp": "192.168.196.186",
+      "cognitoAuthenticationType": "theCognitoAuthenticationType",
+      "cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",
+      "userArn": "theUserArn",
+      "userAgent": "PostmanRuntime/2.4.5",
+      "user": "theUser"
+    },
+    "authorizer": {
+      "principalId": "admin",
+      "clientId": 1,
+      "clientName": "Exata"
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "gy415nuibc"
+  },
+  "body": "{\r\n\t\"a\": 1\r\n}"
+}


### PR DESCRIPTION
operationName is included by API Gateway for API's that were imported through OpenAPI spec.

*Issue #, if available:*
N/A
*Description of changes:*
API Gateway APIGatewayProxyRequestContext varies depending on the way how the API is being created. If I use `aws apigateway import-rest-api` [See](https://docs.aws.amazon.com/cli/latest/reference/apigateway/import-rest-api.html). The model of the event used to call Lambda will contain additional attribute.

One of such attributes is `operationName` that will be populated from OpenAPI operationId attribute.

This pull request adds this additional field to allow handling it on the Lambda side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
