### PR TITLE
Fix #218 - remove omitempty from SessionAttributes in LexResponse

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -46,7 +46,7 @@ type SessionAttributes map[string]string
 type Slots map[string]*string
 
 type LexResponse struct {
-	SessionAttributes SessionAttributes `json:"sessionAttributes,omitempty"`
+	SessionAttributes SessionAttributes `json:"sessionAttributes"`
 	DialogAction      LexDialogAction   `json:"dialogAction,omitempty"`
 }
 


### PR DESCRIPTION
*Issue #, if available: #218 

*Description of changes:*
 remove omitempty from SessionAttributes in LexResponse

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
