### PR TITLE
205 fix mini panic

### DIFF
--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -19,7 +19,7 @@ type DynamoDBAttributeValue struct {
 }
 
 // This struct represents DynamoDBAttributeValue which doesn't
-// implement fmt.Stringer interface and safely printable
+// implement fmt.Stringer interface and safely `fmt.Sprintf`able
 type dynamoDbAttributeValue DynamoDBAttributeValue
 
 // Binary provides access to an attribute of type Binary.
@@ -105,9 +105,9 @@ func (av DynamoDBAttributeValue) String() string {
 	if av.dataType == DataTypeString {
 		return av.value.(string)
 	}
-	// If datatype is not string and you try to print the struct
-	// compiler would confuse with fmt.Stringer interface and would panic
-	// instead of printing the struct
+	// If dataType is not DataTypeString during fmt.Sprintf("%#v", ...)
+	// compiler confuses with fmt.Stringer interface and panics
+	// instead of printing the struct.
 	return fmt.Sprintf("%v", dynamoDbAttributeValue(av))
 }
 

--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -223,8 +223,6 @@ const (
 	DataTypeStringSet
 )
 
-type dynamodbString string
-
 type anyValue interface{}
 
 // UnsupportedDynamoDBTypeError is the error returned when trying to unmarshal a DynamoDB Attribute type not recognized by this library

--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -18,6 +18,10 @@ type DynamoDBAttributeValue struct {
 	dataType DynamoDBDataType
 }
 
+// This struct represents DynamoDBAttributeValue which doesn't
+// implement fmt.Stringer interface and safely printable
+type dynamoDbAttributeValue DynamoDBAttributeValue
+
 // Binary provides access to an attribute of type Binary.
 // Method panics if the attribute is not of type Binary.
 func (av DynamoDBAttributeValue) Binary() []byte {
@@ -98,8 +102,13 @@ func (av DynamoDBAttributeValue) NumberSet() []string {
 // String provides access to an attribute of type String.
 // Method panics if the attribute is not of type String.
 func (av DynamoDBAttributeValue) String() string {
-	av.ensureType(DataTypeString)
-	return av.value.(string)
+	if av.dataType == DataTypeString {
+		return av.value.(string)
+	}
+	// If datatype is not string and you try to print the struct
+	// compiler would confuse with fmt.Stringer interface and would panic
+	// instead of printing the struct
+	return fmt.Sprintf("%v", dynamoDbAttributeValue(av))
 }
 
 // StringSet provides access to an attribute of type String Set.
@@ -213,6 +222,8 @@ const (
 	DataTypeString
 	DataTypeStringSet
 )
+
+type dynamodbString string
 
 type anyValue interface{}
 


### PR DESCRIPTION
*Issue #205*

*Description of changes:*

Came across this bug the other day and spent quite a long time to figure out what's going on because it is really confusing. 

So this is a fix proposal to check if the `av.dataType` is not `DataTypeString` return the string representation of the struct, panic otherwise
