### PR TITLE
Fix Precision issue with Durations

### DIFF
--- a/events/duration.go
+++ b/events/duration.go
@@ -9,7 +9,7 @@ import (
 type DurationSeconds time.Duration
 
 func (duration *DurationSeconds) UnmarshalJSON(data []byte) error {
-	var seconds int64
+	var seconds float64
 	if err := json.Unmarshal(data, &seconds); err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func (duration DurationSeconds) MarshalJSON() ([]byte, error) {
 type DurationMinutes time.Duration
 
 func (duration *DurationMinutes) UnmarshalJSON(data []byte) error {
-	var minutes int64
+	var minutes float64
 	if err := json.Unmarshal(data, &minutes); err != nil {
 		return err
 	}

--- a/events/testdata/codebuild-phase-change.json
+++ b/events/testdata/codebuild-phase-change.json
@@ -27,7 +27,7 @@
                 "type": "LINUX_CONTAINER",
                 "environment-variables": []
             },
-            "timeout-in-minutes": 60,
+            "timeout-in-minutes": 60.0,
             "build-complete": true,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
@@ -45,7 +45,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:12:29 PM",
                     "end-time": "Sep 1, 2017 4:12:29 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "SUBMITTED",
                     "phase-status": "SUCCEEDED"
                 },
@@ -53,7 +53,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:12:29 PM",
                     "end-time": "Sep 1, 2017 4:13:05 PM",
-                    "duration-in-seconds": 36,
+                    "duration-in-seconds": 36.0,
                     "phase-type": "PROVISIONING",
                     "phase-status": "SUCCEEDED"
                 },
@@ -61,7 +61,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:05 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 4,
+                    "duration-in-seconds": 4.0,
                     "phase-type": "DOWNLOAD_SOURCE",
                     "phase-status": "SUCCEEDED"
                 },
@@ -69,7 +69,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "INSTALL",
                     "phase-status": "SUCCEEDED"
                 },
@@ -77,7 +77,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "PRE_BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -85,7 +85,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 70,
+                    "duration-in-seconds": 70.0,
                     "phase-type": "BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -93,7 +93,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "POST_BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -101,7 +101,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "UPLOAD_ARTIFACTS",
                     "phase-status": "SUCCEEDED"
                 },
@@ -109,7 +109,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:26 PM",
-                    "duration-in-seconds": 4,
+                    "duration-in-seconds": 4.0,
                     "phase-type": "FINALIZING",
                     "phase-status": "SUCCEEDED"
                 },
@@ -120,7 +120,7 @@
             ]
         },
         "completed-phase-status": "SUCCEEDED",
-        "completed-phase-duration-seconds": 4,
+        "completed-phase-duration-seconds": 4.0,
         "version": "1",
         "completed-phase-start": "Sep 1, 2017 4:14:21 PM",
         "completed-phase-end": "Sep 1, 2017 4:14:26 PM"

--- a/events/testdata/codebuild-state-change.json
+++ b/events/testdata/codebuild-state-change.json
@@ -32,7 +32,7 @@
                     }
                 ]
             },
-            "timeout-in-minutes": 60,
+            "timeout-in-minutes": 60.0,
             "build-complete": true,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
@@ -50,7 +50,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:12:29 PM",
                     "end-time": "Sep 1, 2017 4:12:29 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "SUBMITTED",
                     "phase-status": "SUCCEEDED"
                 },
@@ -58,7 +58,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:12:29 PM",
                     "end-time": "Sep 1, 2017 4:13:05 PM",
-                    "duration-in-seconds": 36,
+                    "duration-in-seconds": 36.0,
                     "phase-type": "PROVISIONING",
                     "phase-status": "SUCCEEDED"
                 },
@@ -66,7 +66,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:05 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 4,
+                    "duration-in-seconds": 4.0,
                     "phase-type": "DOWNLOAD_SOURCE",
                     "phase-status": "SUCCEEDED"
                 },
@@ -74,7 +74,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "INSTALL",
                     "phase-status": "SUCCEEDED"
                 },
@@ -82,7 +82,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:13:10 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "PRE_BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -90,7 +90,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:13:10 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 70,
+                    "duration-in-seconds": 70.0,
                     "phase-type": "BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -98,7 +98,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "POST_BUILD",
                     "phase-status": "SUCCEEDED"
                 },
@@ -106,7 +106,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:21 PM",
-                    "duration-in-seconds": 0,
+                    "duration-in-seconds": 0.0,
                     "phase-type": "UPLOAD_ARTIFACTS",
                     "phase-status": "SUCCEEDED"
                 },
@@ -114,7 +114,7 @@
                     "phase-context": [],
                     "start-time": "Sep 1, 2017 4:14:21 PM",
                     "end-time": "Sep 1, 2017 4:14:26 PM",
-                    "duration-in-seconds": 4,
+                    "duration-in-seconds": 4.0,
                     "phase-type": "FINALIZING",
                     "phase-status": "SUCCEEDED"
                 },


### PR DESCRIPTION
* CloudWatchEvents seem to return with precision 60.0 instead of 60
* Change tests to match
* Change types to float64

#228 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
