### PR TITLE
Add missing 'apiKeyId' to APIGatewayRequestIdentity

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -49,6 +49,7 @@ type APIGatewayRequestIdentity struct {
 	CognitoIdentityID             string `json:"cognitoIdentityId"`
 	Caller                        string `json:"caller"`
 	APIKey                        string `json:"apiKey"`
+	APIKeyID                      string `json:"apiKeyId"`
 	AccessKey                     string `json:"accessKey"`
 	SourceIP                      string `json:"sourceIp"`
 	CognitoAuthenticationType     string `json:"cognitoAuthenticationType"`

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -1,4 +1,4 @@
-{ 
+{
 	"resource": "/{proxy+}",
 	  "path": "/hello/world",
 	  "httpMethod": "POST",
@@ -67,6 +67,7 @@
 			"cognitoIdentityId": "theCognitoIdentityId",
 			"caller": "theCaller",
             "apiKey": "theApiKey",
+            "apiKeyId": "theApiKeyId",
             "accessKey": "ANEXAMPLEOFACCESSKEY",
 			"sourceIp": "192.168.196.186",
 			"cognitoAuthenticationType": "theCognitoAuthenticationType",
@@ -79,7 +80,7 @@
 			"principalId": "admin",
 			"clientId": 1,
 			"clientName": "Exata"
-		},	
+		},
 		"resourcePath": "/{proxy+}",
 		"httpMethod": "POST",
 		"apiId": "gy415nuibc"

--- a/events/testdata/apigw-restapi-openapi-request.json
+++ b/events/testdata/apigw-restapi-openapi-request.json
@@ -68,6 +68,7 @@
       "cognitoIdentityId": "theCognitoIdentityId",
       "caller": "theCaller",
       "apiKey": "theApiKey",
+      "apiKeyId": "theApiKeyId",
       "accessKey": "ANEXAMPLEOFACCESSKEY",
       "sourceIp": "192.168.196.186",
       "cognitoAuthenticationType": "theCognitoAuthenticationType",

--- a/events/testdata/apigw-websocket-request.json
+++ b/events/testdata/apigw-websocket-request.json
@@ -72,6 +72,7 @@
       "cognitoIdentityId": "theCognitoIdentityId",
       "caller": "theCaller",
       "apiKey": "theApiKey",
+      "apiKeyId": "theApiKeyId",
       "accessKey": "ANEXAMPLEOFACCESSKEY",
       "sourceIp": "192.168.196.186",
       "cognitoAuthenticationType": "theCognitoAuthenticationType",


### PR DESCRIPTION
*Description of changes:* Adding missing `apiKeyId` to `APIGatewayRequestIdentity`

Similar issue / changes - https://github.com/awslabs/aws-serverless-java-container/issues/136
Some documentation that makes reference to `apiKeyId` - [api-gateway-mapping-template-reference](https://docs.aws.amazon.com/en_pv/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html)

Also happy to add anything that's required to get this through

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
