### PR TITLE
revert #108 to fix #237

### DIFF
--- a/cfn/wrap.go
+++ b/cfn/wrap.go
@@ -41,16 +41,17 @@ func lambdaWrapWithClient(lambdaFunction CustomResourceFunction, client httpClie
 		r.PhysicalResourceID, r.Data, err = lambdaFunction(ctx, event)
 		funcDidPanic = false
 
-		if r.PhysicalResourceID == "" {
-			log.Println("PhysicalResourceID must exist, copying Log Stream name")
-			r.PhysicalResourceID = lambdacontext.LogStreamName
-		}
 		if err != nil {
 			r.Status = StatusFailed
 			r.Reason = err.Error()
 			log.Printf("sending status failed: %s", r.Reason)
 		} else {
 			r.Status = StatusSuccess
+
+			if r.PhysicalResourceID == "" {
+				log.Println("PhysicalResourceID must exist on creation, copying Log Stream name")
+				r.PhysicalResourceID = lambdacontext.LogStreamName
+			}
 		}
 
 		err = r.sendWith(client)


### PR DESCRIPTION
#237 described a problem deleting resources on rollback. If merged, we should re-open #107 which describes a visibility problem on custom resource creation failures.
