### PR TITLE
Add CloudWatch README

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -14,6 +14,10 @@ This package provides input types for Lambda functions that process AWS events.
 
 [CloudFormation Events](../cfn/README.md)
 
+[CloudWatch Events](README_CloudWatch_Events.md)
+
+[CloudWatch Logs](README_CloudWatch_Logs.md)
+
 [Chime Bot Events](README_Chime_Bots.md)
 
 [Code Commit Events](README_CodeCommit.md)

--- a/events/README_CloudWatch_Events.md
+++ b/events/README_CloudWatch_Events.md
@@ -1,0 +1,17 @@
+
+# Sample Function
+
+The following is a Lambda function that receives Amazon CloudWatch event record data as input and writes event detail to Lambda's CloudWatch Logs. Note that by default anything written to Console will be logged as CloudWatch Logs events.
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func handler(ctx context.Context, event events.CloudWatchEvent) {
+  fmt.Printf("Detail = %s\n", event.Detail)
+}
+```

--- a/events/README_CloudWatch_Events.md
+++ b/events/README_CloudWatch_Events.md
@@ -12,6 +12,6 @@ import (
 )
 
 func handler(ctx context.Context, event events.CloudWatchEvent) {
-  fmt.Printf("Detail = %s\n", event.Detail)
+	fmt.Printf("Detail = %s\n", event.Detail)
 }
 ```

--- a/events/README_CloudWatch_Logs.md
+++ b/events/README_CloudWatch_Logs.md
@@ -12,9 +12,9 @@ import (
 )
 
 func handler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
-  data, _ := logsEvent.AWSLogs.Parse()
-  for _, logEvent := range data.LogEvents {
-    fmt.Printf("Message = %s\n", logEvent.Message)
-  }
+	data, _ := logsEvent.AWSLogs.Parse()
+	for _, logEvent := range data.LogEvents {
+		fmt.Printf("Message = %s\n", logEvent.Message)
+  	}
 }
 ```

--- a/events/README_CloudWatch_Logs.md
+++ b/events/README_CloudWatch_Logs.md
@@ -1,0 +1,20 @@
+
+# Sample Function
+
+The following is a Lambda function that receives Amazon CloudWatch Logs event record data as input and writes message part to Lambda's CloudWatch Logs. Note that by default anything written to Console will be logged as CloudWatch Logs events.
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func handler(ctx context.Context, logsEvent events.CloudwatchLogsEvent) {
+  data, _ := logsEvent.AWSLogs.Parse()
+  for _, logEvent := range data.LogEvents {
+    fmt.Printf("Message = %s\n", logEvent.Message)
+  }
+}
+```


### PR DESCRIPTION
The library provides events for the CloudWatch Event and Logs, but they are not reflected in the documentation.

### Related PRs

- awsdocs/aws-lambda-developer-guide#141

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.