### PR TITLE
build-lambda-zip: pass pointer to cli.StringFlag instead of value

### DIFF
--- a/cmd/build-lambda-zip/main.go
+++ b/cmd/build-lambda-zip/main.go
@@ -16,7 +16,7 @@ func main() {
 	app.Name = "build-lambda-zip"
 	app.Usage = "Put an executable and supplemental files into a zip file that works with AWS Lambda."
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "output, o",
 			Value: "",
 			Usage: "output file path for the zip. Defaults to the first input file name.",


### PR DESCRIPTION
*Issue #, if available:*

#248

*Description of changes:*

Without this change, the following compile error is seen when installing `build-lambda-zip` using `go get`

```
$ go get -u github.com/bmoffatt/aws-lambda-go/cmd/build-lambda-zip
# github.com/bmoffatt/aws-lambda-go/cmd/build-lambda-zip
go/src/github.com/bmoffatt/aws-lambda-go/cmd/build-lambda-zip/main.go:19:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
```

after pushing this change to my fork `go get -u github.com/bmoffatt/aws-lambda-go/cmd/build-lambda-zip` works as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
