### PR TITLE
Update build-lambda-zip instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Windows developers may have trouble producing a zip file that marks the binary a
 
 Get the tool
 ``` shell
+set GO111MODULE=on
 go.exe get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip
 ```
 


### PR DESCRIPTION
This should mitigate the dependency locking issues people have been reporting