### PR TITLE
Add goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Go Dep
-vendor
+# Temporary folder used by goreleaser.
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,41 @@
+project_name: aws-lambda-go
+env:
+  - GO111MODULE=on
+
+builds:
+  - id: build-lambda-zip
+    main: cmd/build-lambda-zip/main.go
+    binary: cmd/build-lambda-zip/build-lambda-zip
+    flags:
+      - -trimpath
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - 386
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
+    builds:
+      - build-lambda-zip
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - LICENSE-LAMBDACODE
+      - LICENSE-SUMMARY
+      - README.md
+
+checksum:
+  name_template: checksum
+  algorithm: sha256
+
+release:
+  draft: true
+  github:
+    owner: aws
+    name: aws-lambda-go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+release:
+	@goreleaser release --rm-dist


### PR DESCRIPTION
*Description of changes:*
Add [goreleaser](https://github.com/goreleaser/goreleaser) to manage the release of new versions of the project.

The only 'problem' I found was related with the build part. It's injecting default ldflags. We're not using those flags, so I don't think that we gonna have any problem with that. This behaviour can be checked by running this command: `goreleaser release --rm-dist --snapshot --debug`:

```go build -trimpath -ldflags=-s -w -X main.version=v1.13.2-SNAPSHOT-072cade -X main.commit=072cadec8de74ff48a679ccc26ebfe7e4b22713d -X main.date=2019-11-20T18:45:04Z -X main.builtBy=goreleaser -o ...```

Output:
```
 ➜ make release
 • releasing using goreleaser 0.122.0...
   • loading config file       file=.goreleaser.yml
   • RUNNING BEFORE HOOKS
   • LOADING ENVIRONMENT VARIABLES
      • pipe skipped              error=publishing is disabled
   • GETTING AND VALIDATING GIT STATE
      • releasing v1.13.2, commit 072cadec8de74ff48a679ccc26ebfe7e4b22713d
      • pipe skipped              error=disabled during snapshot mode
   • PARSING TAG
   • SETTING DEFAULTS
      • LOADING ENVIRONMENT VARIABLES
      • SNAPSHOTING
      • GITHUB/GITLAB/GITEA RELEASES
      • PROJECT NAME
      • BUILDING BINARIES
      • ARCHIVES
      • LINUX PACKAGES WITH NFPM
      • SNAPCRAFT PACKAGES
      • CALCULATING CHECKSUMS
      • SIGNING ARTIFACTS
      • DOCKER IMAGES
      • ARTIFACTORY
      • S3
      • BLOB
      • HOMEBREW TAP FORMULA
         • optimistically guessing `brew[0].installs`, double check
      • SCOOP MANIFEST
   • SNAPSHOTING
   • CHECKING ./DIST
      • --rm-dist is set, cleaning it up
   • WRITING EFFECTIVE CONFIG FILE
      • writing                   config=dist/config.yaml
   • GENERATING CHANGELOG
      • pipe skipped              error=not available for snapshots
   • BUILDING BINARIES
      • building                  binary=dist/build-lambda-zip_windows_386/cmd/build-lambda-zip/build-lambda-zip.exe
      • building                  binary=dist/build-lambda-zip_darwin_amd64/cmd/build-lambda-zip/build-lambda-zip
      • building                  binary=dist/build-lambda-zip_darwin_386/cmd/build-lambda-zip/build-lambda-zip
      • building                  binary=dist/build-lambda-zip_windows_amd64/cmd/build-lambda-zip/build-lambda-zip.exe
      • building                  binary=dist/build-lambda-zip_linux_amd64/cmd/build-lambda-zip/build-lambda-zip
      • building                  binary=dist/build-lambda-zip_linux_386/cmd/build-lambda-zip/build-lambda-zip
   • ARCHIVES
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_windows_386.zip
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_linux_386.tar.gz
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_darwin_386.tar.gz
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_darwin_amd64.tar.gz
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_windows_amd64.zip
      • creating                  archive=dist/aws-lambda-go_v1.13.2-SNAPSHOT-072cade_linux_amd64.tar.gz
   • LINUX PACKAGES WITH NFPM
      • pipe skipped              error=no output formats configured
   • SNAPCRAFT PACKAGES
      • pipe skipped              error=no summary nor description were provided
   • CALCULATING CHECKSUMS
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_linux_amd64.tar.gz
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_darwin_386.tar.gz
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_windows_386.zip
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_linux_386.tar.gz
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_darwin_amd64.tar.gz
      • checksumming              file=aws-lambda-go_v1.13.2-SNAPSHOT-072cade_windows_amd64.zip
   • SIGNING ARTIFACTS
      • pipe skipped              error=artifact signing is disabled
   • DOCKER IMAGES
      • pipe skipped              error=docker section is not configured
   • PUBLISHING
      • pipe skipped              error=publishing is disabled
   • release succeeded after 2.71s
```

[Instructions](https://goreleaser.com/install/) to install goreleaser.

--- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
