### PR TITLE
Fix dead kinesis firehose tests

### DIFF
--- a/events/firehose.go
+++ b/events/firehose.go
@@ -39,5 +39,6 @@ type KinesisFirehoseRecordMetadata struct {
 	ShardID                     string                `json:"shardId"`
 	PartitionKey                string                `json:"partitionKey"`
 	SequenceNumber              string                `json:"sequenceNumber"`
+	SubsequenceNumber           string                `json:"subsequenceNumber"`
 	ApproximateArrivalTimestamp MilliSecondsEpochTime `json:"approximateArrivalTimestamp"`
 }

--- a/events/firehose_test.go
+++ b/events/firehose_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testFirehoseEventMarshaling(t *testing.T) {
+func TestFirehoseEventMarshaling(t *testing.T) {
 	testMarshaling(t, "./testdata/kinesis-firehose-event.json")
 }
 
-func testFirehoseResponseMarshaling(t *testing.T) {
+func TestFirehoseResponseMarshaling(t *testing.T) {
 	testMarshaling(t, "./testdata/kinesis-firehose-response.json")
 }
 

--- a/events/firehose_test.go
+++ b/events/firehose_test.go
@@ -12,19 +12,18 @@ import (
 )
 
 func TestFirehoseEventMarshaling(t *testing.T) {
-	testMarshaling(t, "./testdata/kinesis-firehose-event.json")
+	testMarshaling(t, &KinesisFirehoseEvent{}, "./testdata/kinesis-firehose-event.json")
 }
 
 func TestFirehoseResponseMarshaling(t *testing.T) {
-	testMarshaling(t, "./testdata/kinesis-firehose-response.json")
+	testMarshaling(t, &KinesisFirehoseResponse{}, "./testdata/kinesis-firehose-response.json")
 }
 
-func testMarshaling(t *testing.T, jsonFile string) {
+func testMarshaling(t *testing.T, inputEvent interface{}, jsonFile string) {
 	// 1. read JSON from file
 	inputJson := test.ReadJSONFromFile(t, jsonFile)
 
 	// 2. de-serialize into Go object
-	var inputEvent KinesisFirehoseEvent
 	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}

--- a/events/testdata/kinesis-firehose-event.json
+++ b/events/testdata/kinesis-firehose-event.json
@@ -13,7 +13,7 @@
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c317a",
          "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785154",
-         "subsequenceNumber": ""
+         "subsequenceNumber": "123456"
        }
      },
      {
@@ -25,7 +25,7 @@
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c318a",
          "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785155",
-         "subsequenceNumber": ""
+         "subsequenceNumber": "123457"
        }
      }
    ]


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Discovered two tests that weren't being run while working on #164. Enabled the tests, and fixed the assertions.

This adds the `subsequenceNumber` field to `KinesisFirehoseRecordMetadata`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
