### PR TITLE
Add clientMetadata to triggers that support it

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -88,6 +88,7 @@ type CognitoEventUserPoolsHeader struct {
 type CognitoEventUserPoolsPreSignupRequest struct {
 	UserAttributes map[string]string `json:"userAttributes"`
 	ValidationData map[string]string `json:"validationData"`
+	ClientMetadata map[string]string `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsPreSignupResponse contains the response portion of a PreSignup event
@@ -110,6 +111,7 @@ type CognitoEventUserPoolsPreAuthenticationResponse struct {
 // CognitoEventUserPoolsPostConfirmationRequest contains the request portion of a PostConfirmation event
 type CognitoEventUserPoolsPostConfirmationRequest struct {
 	UserAttributes map[string]string `json:"userAttributes"`
+	ClientMetadata map[string]string `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsPostConfirmationResponse contains the response portion of a PostConfirmation event
@@ -120,6 +122,7 @@ type CognitoEventUserPoolsPostConfirmationResponse struct {
 type CognitoEventUserPoolsPreTokenGenRequest struct {
 	UserAttributes     map[string]string  `json:"userAttributes"`
 	GroupConfiguration GroupConfiguration `json:"groupConfiguration"`
+	ClientMetadata     map[string]string  `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsPreTokenGenResponse containst the response portion of  a PreTokenGen event
@@ -131,6 +134,7 @@ type CognitoEventUserPoolsPreTokenGenResponse struct {
 type CognitoEventUserPoolsPostAuthenticationRequest struct {
 	NewDeviceUsed  bool              `json:"newDeviceUsed"`
 	UserAttributes map[string]string `json:"userAttributes"`
+	ClientMetadata map[string]string `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsPostAuthenticationResponse contains the response portion of a PostAuthentication event
@@ -139,7 +143,8 @@ type CognitoEventUserPoolsPostAuthenticationResponse struct {
 
 // CognitoEventUserPoolsMigrateUserRequest contains the request portion of a MigrateUser event
 type CognitoEventUserPoolsMigrateUserRequest struct {
-	Password string `json:"password"`
+	Password       string            `json:"password"`
+	ClientMetadata map[string]string `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsMigrateUserResponse contains the response portion of a MigrateUser event
@@ -177,6 +182,7 @@ type CognitoEventUserPoolsChallengeResult struct {
 type CognitoEventUserPoolsDefineAuthChallengeRequest struct {
 	UserAttributes map[string]string                       `json:"userAttributes"`
 	Session        []*CognitoEventUserPoolsChallengeResult `json:"session"`
+	ClientMetadata map[string]string                       `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsDefineAuthChallengeResponse defines auth challenge response parameters
@@ -198,6 +204,7 @@ type CognitoEventUserPoolsCreateAuthChallengeRequest struct {
 	UserAttributes map[string]string                       `json:"userAttributes"`
 	ChallengeName  string                                  `json:"challengeName"`
 	Session        []*CognitoEventUserPoolsChallengeResult `json:"session"`
+	ClientMetadata map[string]string                       `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsCreateAuthChallengeResponse defines create auth challenge response rarameters
@@ -219,6 +226,7 @@ type CognitoEventUserPoolsVerifyAuthChallengeRequest struct {
 	UserAttributes             map[string]string `json:"userAttributes"`
 	PrivateChallengeParameters map[string]string `json:"privateChallengeParameters"`
 	ChallengeAnswer            interface{}       `json:"challengeAnswer"`
+	ClientMetadata             map[string]string `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsVerifyAuthChallengeResponse defines verify auth challenge response parameters
@@ -247,6 +255,7 @@ type CognitoEventUserPoolsCustomMessageRequest struct {
 	UserAttributes    map[string]interface{} `json:"userAttributes"`
 	CodeParameter     string                 `json:"codeParameter"`
 	UsernameParameter string                 `json:"usernameParameter"`
+	ClientMetadata    map[string]string      `json:"clientMetadata"`
 }
 
 // CognitoEventUserPoolsCustomMessageResponse contains the response portion of a CustomMessage event

--- a/events/testdata/cognito-event-userpools-create-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-create-auth-challenge.json
@@ -23,7 +23,10 @@
         "challengeResult": true,
         "challengeMetadata": "metadata"
       }
-    ]
+    ],
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    }
   },
   "response": {
     "publicChallengeParameters": {

--- a/events/testdata/cognito-event-userpools-custommessage.json
+++ b/events/testdata/cognito-event-userpools-custommessage.json
@@ -14,7 +14,10 @@
           "email_verified": false
        },
       "codeParameter": "####",
-      "usernameParameter": "{username}"
+      "usernameParameter": "{username}",
+      "clientMetadata": {
+        "exampleMetadataKey": "example metadata value"
+      }
   },
   "response": {
       "smsMessage": "<custom message to be sent in the message with code parameter>",

--- a/events/testdata/cognito-event-userpools-define-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-define-auth-challenge.json
@@ -22,7 +22,10 @@
         "challengeResult": true,
         "challengeMetadata": "metadata"
       }
-    ]
+    ],
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    }
   },
   "response": {
     "challengeName": "challengeName",

--- a/events/testdata/cognito-event-userpools-migrateuser.json
+++ b/events/testdata/cognito-event-userpools-migrateuser.json
@@ -9,7 +9,10 @@
         "clientId": "<apps client id>"
     },
     "request": {
-        "password": "<password>"
+        "password": "<password>",
+        "clientMetadata": {
+            "exampleMetadataKey": "example metadata value"
+          }
     },
     "response": {
         "userAttributes": {

--- a/events/testdata/cognito-event-userpools-postauthentication.json
+++ b/events/testdata/cognito-event-userpools-postauthentication.json
@@ -13,6 +13,9 @@
       "userAttributes" : {
           "email": "<email>",
           "phone_number": "<phone_number>"
+      },
+      "clientMetadata": {
+        "exampleMetadataKey": "example metadata value"
       }
   },
   "response": {}

--- a/events/testdata/cognito-event-userpools-postconfirmation.json
+++ b/events/testdata/cognito-event-userpools-postconfirmation.json
@@ -12,6 +12,9 @@
       "userAttributes" : {
           "email": "<email>",
           "phone_number": "<phone_number>"
+      },
+      "clientMetadata": {
+        "exampleMetadataKey": "example metadata value"
       }
   },
   "response": {}

--- a/events/testdata/cognito-event-userpools-presignup.json
+++ b/events/testdata/cognito-event-userpools-presignup.json
@@ -16,7 +16,10 @@
       "validationData": {
           "k1": "v1",
           "k2": "v2"
-       }
+       },
+       "clientMetadata": {
+        "exampleMetadataKey": "example metadata value"
+      }
   },
   "response": {
       "autoConfirmUser": false,

--- a/events/testdata/cognito-event-userpools-pretokengen.json
+++ b/events/testdata/cognito-event-userpools-pretokengen.json
@@ -17,6 +17,9 @@
       "groupsToOverride": ["group-A", "group-B", "group-C"],
       "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
       "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+    },
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
     }
   },
   "response": {

--- a/events/testdata/cognito-event-userpools-verify-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-verify-auth-challenge.json
@@ -19,7 +19,10 @@
     "privateChallengeParameters": {
       "secret": "11122233"
     },
-    "challengeAnswer": "123xxxx"
+    "challengeAnswer": "123xxxx",
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    }
   },
   "response": {
     "answerCorrect": true


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/255

*Description of changes:*

Request structs for triggers are updated with a ClientMetadata field when supported as noted in the documentation under https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
