### PR TITLE
Update build-lambda-zip workflow

### DIFF
--- a/.github/workflows/build-lambda-zip.yml
+++ b/.github/workflows/build-lambda-zip.yml
@@ -1,8 +1,10 @@
 name: go get build-lambda-zip 
 on:
   push:
+    branches: 
+      - master
   schedule:
-    - cron: "7 7 * * *"
+    - cron: "7 7 * * 7"
 
 jobs:
   thejob:
@@ -24,4 +26,4 @@ jobs:
           GO111MODULE: on
         run: |
           go env
-          go get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip
+          go get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip@master

--- a/.github/workflows/build-lambda-zip.yml
+++ b/.github/workflows/build-lambda-zip.yml
@@ -4,7 +4,7 @@ on:
     branches: 
       - master
   schedule:
-    - cron: "7 7 * * 7"
+    - cron: "7 7 * * *"
 
 jobs:
   thejob:


### PR DESCRIPTION
I noticed that the action after most recent push (#266) pulled and installed the latest release (v1.14.0) rather than on master

*Description of changes:*

* run on push to master
* explicit go get @master

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
