### PR TITLE
Update _X_AMZN_TRACE_ID on every invoke

### DIFF
--- a/lambda/function.go
+++ b/lambda/function.go
@@ -5,6 +5,7 @@ package lambda
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"reflect"
 	"time"
 
@@ -63,6 +64,7 @@ func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.Invok
 	invokeContext = lambdacontext.NewContext(invokeContext, lc)
 
 	invokeContext = context.WithValue(invokeContext, "x-amzn-trace-id", req.XAmznTraceId)
+	os.Setenv("_X_AMZN_TRACE_ID", req.XAmznTraceId)
 
 	payload, err := fn.handler.Invoke(invokeContext, req.Payload)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

#236 

*Description of changes:*

Updates the value of the environment variable _X_AMZN_TRACE_ID on every invoke. This is consistent with [the docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html#lambda-x-ray-env-variables)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
