### PR TITLE
Remove nested structure definitions for `APIGatewayV2HTTPRequestContext`

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -60,28 +60,37 @@ type APIGatewayV2HTTPRequest struct {
 
 // APIGatewayV2HTTPRequestContext contains the information to identify the AWS account and resources invoking the Lambda function.
 type APIGatewayV2HTTPRequestContext struct {
-	RouteKey   string `json:"routeKey"`
-	AccountID  string `json:"accountId"`
-	Stage      string `json:"stage"`
-	RequestID  string `json:"requestId"`
-	Authorizer struct {
-		JWT struct {
-			Claims map[string]string `json:"claims"`
-			Scopes []string          `json:"scopes"`
-		} `json:"jwt"`
-	} `json:"authorizer"`
-	APIID        string `json:"apiId"` // The API Gateway HTTP API Id
-	DomainName   string `json:"domainName"`
-	DomainPrefix string `json:"domainPrefix"`
-	Time         string `json:"time"`
-	TimeEpoch    int64  `json:"timeEpoch"`
-	HTTP         struct {
-		Method    string `json:"method"`
-		Path      string `json:"path"`
-		Protocol  string `json:"protocol"`
-		SourceIP  string `json:"sourceIp"`
-		UserAgent string `json:"userAgent"`
-	} `json:"http"`
+	RouteKey     string                                              `json:"routeKey"`
+	AccountID    string                                              `json:"accountId"`
+	Stage        string                                              `json:"stage"`
+	RequestID    string                                              `json:"requestId"`
+	Authorizer   APIGatewayV2HTTPRequestContextAuthorizerDescription `json:"authorizer"`
+	APIID        string                                              `json:"apiId"` // The API Gateway HTTP API Id
+	DomainName   string                                              `json:"domainName"`
+	DomainPrefix string                                              `json:"domainPrefix"`
+	Time         string                                              `json:"time"`
+	TimeEpoch    int64                                               `json:"timeEpoch"`
+	HTTP         APIGatewayV2HTTPRequestContextHttpDescription       `json:"http"`
+}
+
+// APIGatewayV2HTTPRequestContextAuthorizerDescription contains authorizer information for the request context.
+type APIGatewayV2HTTPRequestContextAuthorizerDescription struct {
+	JWT APIGatewayV2HTTPRequestContextAuthorizerJwtDescription `json:"jwt"`
+}
+
+// APIGatewayV2HTTPRequestContextAuthorizerJwtDescription contains JWT authorizer information for the request context.
+type APIGatewayV2HTTPRequestContextAuthorizerJwtDescription struct {
+	Claims map[string]string `json:"claims"`
+	Scopes []string          `json:"scopes"`
+}
+
+// APIGatewayV2HTTPRequestContextHttpDescription contains HTTP information for the request context.
+type APIGatewayV2HTTPRequestContextHttpDescription struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Protocol  string `json:"protocol"`
+	SourceIP  string `json:"sourceIp"`
+	UserAgent string `json:"userAgent"`
 }
 
 // APIGatewayRequestIdentity contains identity information for the request caller.

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -70,22 +70,22 @@ type APIGatewayV2HTTPRequestContext struct {
 	DomainPrefix string                                              `json:"domainPrefix"`
 	Time         string                                              `json:"time"`
 	TimeEpoch    int64                                               `json:"timeEpoch"`
-	HTTP         APIGatewayV2HTTPRequestContextHttpDescription       `json:"http"`
+	HTTP         APIGatewayV2HTTPRequestContextHTTPDescription       `json:"http"`
 }
 
 // APIGatewayV2HTTPRequestContextAuthorizerDescription contains authorizer information for the request context.
 type APIGatewayV2HTTPRequestContextAuthorizerDescription struct {
-	JWT APIGatewayV2HTTPRequestContextAuthorizerJwtDescription `json:"jwt"`
+	JWT APIGatewayV2HTTPRequestContextAuthorizerJWTDescription `json:"jwt"`
 }
 
 // APIGatewayV2HTTPRequestContextAuthorizerJwtDescription contains JWT authorizer information for the request context.
-type APIGatewayV2HTTPRequestContextAuthorizerJwtDescription struct {
+type APIGatewayV2HTTPRequestContextAuthorizerJWTDescription struct {
 	Claims map[string]string `json:"claims"`
 	Scopes []string          `json:"scopes"`
 }
 
 // APIGatewayV2HTTPRequestContextHttpDescription contains HTTP information for the request context.
-type APIGatewayV2HTTPRequestContextHttpDescription struct {
+type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	Method    string `json:"method"`
 	Path      string `json:"path"`
 	Protocol  string `json:"protocol"`

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -78,13 +78,13 @@ type APIGatewayV2HTTPRequestContextAuthorizerDescription struct {
 	JWT APIGatewayV2HTTPRequestContextAuthorizerJWTDescription `json:"jwt"`
 }
 
-// APIGatewayV2HTTPRequestContextAuthorizerJwtDescription contains JWT authorizer information for the request context.
+// APIGatewayV2HTTPRequestContextAuthorizerJWTDescription contains JWT authorizer information for the request context.
 type APIGatewayV2HTTPRequestContextAuthorizerJWTDescription struct {
 	Claims map[string]string `json:"claims"`
 	Scopes []string          `json:"scopes"`
 }
 
-// APIGatewayV2HTTPRequestContextHttpDescription contains HTTP information for the request context.
+// APIGatewayV2HTTPRequestContextHTTPDescription contains HTTP information for the request context.
 type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	Method    string `json:"method"`
 	Path      string `json:"path"`

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -230,6 +230,12 @@ func TestApiGatewayV2HTTPRequestMarshaling(t *testing.T) {
 		t.Errorf("could not extract authorizer claim from JWT: %v", authContext)
 	}
 
+	// validate HTTP details
+	http := inputEvent.RequestContext.HTTP
+	if http.Path != "/my/path" {
+		t.Errorf("could not extract HTTP details: %v", http)
+	}
+
 	// serialize to json
 	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws/aws-lambda-go/issues/276.

*Description of changes:*
Removes nested structure definitions for `APIGatewayV2HTTPRequestContext`.

```console
$ go test ./events/
ok  	github.com/aws/aws-lambda-go/events	0.026s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
