### PR TITLE
for -o to work, you specify it as an alias rather than in the Name

### DIFF
--- a/cmd/build-lambda-zip/main.go
+++ b/cmd/build-lambda-zip/main.go
@@ -17,7 +17,8 @@ func main() {
 		Usage: "Put an executable and supplemental files into a zip file that works with AWS Lambda.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "output, o",
+				Name:  "output",
+				Aliases: []string{"o"},
 				Value: "",
 				Usage: "output file path for the zip. Defaults to the first input file name.",
 			},

--- a/cmd/build-lambda-zip/main.go
+++ b/cmd/build-lambda-zip/main.go
@@ -17,10 +17,10 @@ func main() {
 		Usage: "Put an executable and supplemental files into a zip file that works with AWS Lambda.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "output",
+				Name:    "output",
 				Aliases: []string{"o"},
-				Value: "",
-				Usage: "output file path for the zip. Defaults to the first input file name.",
+				Value:   "",
+				Usage:   "output file path for the zip. Defaults to the first input file name.",
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION

*Description of changes:*
Move 'o' to an alias when declaring the flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
