### PR TITLE
Add APIGatewayV2HTTPResponse

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -93,6 +93,16 @@ type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 	UserAgent string `json:"userAgent"`
 }
 
+// APIGatewayV2HTTPResponse configures the response to be returned by API Gateway V2 for the request
+type APIGatewayV2HTTPResponse struct {
+	StatusCode        int                 `json:"statusCode"`
+	Headers           map[string]string   `json:"headers"`
+	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	Body              string              `json:"body"`
+	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
+	Cookies           []string            `json:"cookies"`
+}
+
 // APIGatewayRequestIdentity contains identity information for the request caller.
 type APIGatewayRequestIdentity struct {
 	CognitoIdentityPoolID         string `json:"cognitoIdentityPoolId"`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- ~~There is a new version field for payload format version 1.0. The value is `"1.0"` as expected.~~ Removed this commit since this field only exists in HTTP API (it is present in both payload format version 1.0 and 2.0).
- In payload format version 2.0, you can send cookies in an easier way with the new cookies field. This does not work in 1.0, so I think we want a new struct for that, right?

I used this page as a reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

Maybe someone more knowledgable than me should double check that there aren't other fields that are missing?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
