### PR TITLE
Add missing connectionId field in APIGatewayProxyRequestContext

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -40,6 +40,7 @@ type APIGatewayProxyRequestContext struct {
 	Authorizer    map[string]interface{}    `json:"authorizer"`
 	HTTPMethod    string                    `json:"httpMethod"`
 	APIID         string                    `json:"apiId"` // The API Gateway rest API Id
+	ConnectionId  string			`json:"connectionId"`
 }
 
 // APIGatewayV2HTTPRequest contains data coming from the new HTTP API Gateway


### PR DESCRIPTION
*Description of changes:*

Adds the connectionId field which was missing from this struct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
