### PR TITLE
Tag optional API Gateway v2 HTTP Request fields with 'omitempty'

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -48,29 +48,29 @@ type APIGatewayV2HTTPRequest struct {
 	RouteKey              string                         `json:"routeKey"`
 	RawPath               string                         `json:"rawPath"`
 	RawQueryString        string                         `json:"rawQueryString"`
-	Cookies               []string                       `json:"cookies"`
+	Cookies               []string                       `json:"cookies,omitempty"`
 	Headers               map[string]string              `json:"headers"`
-	QueryStringParameters map[string]string              `json:"queryStringParameters"`
-	PathParameters        map[string]string              `json:"pathParameters"`
+	QueryStringParameters map[string]string              `json:"queryStringParameters,omitempty"`
+	PathParameters        map[string]string              `json:"pathParameters,omitempty"`
 	RequestContext        APIGatewayV2HTTPRequestContext `json:"requestContext"`
-	StageVariables        map[string]string              `json:"stageVariables"`
-	Body                  string                         `json:"body"`
+	StageVariables        map[string]string              `json:"stageVariables,omitempty"`
+	Body                  string                         `json:"body,omitempty"`
 	IsBase64Encoded       bool                           `json:"isBase64Encoded"`
 }
 
 // APIGatewayV2HTTPRequestContext contains the information to identify the AWS account and resources invoking the Lambda function.
 type APIGatewayV2HTTPRequestContext struct {
-	RouteKey     string                                              `json:"routeKey"`
-	AccountID    string                                              `json:"accountId"`
-	Stage        string                                              `json:"stage"`
-	RequestID    string                                              `json:"requestId"`
-	Authorizer   APIGatewayV2HTTPRequestContextAuthorizerDescription `json:"authorizer"`
-	APIID        string                                              `json:"apiId"` // The API Gateway HTTP API Id
-	DomainName   string                                              `json:"domainName"`
-	DomainPrefix string                                              `json:"domainPrefix"`
-	Time         string                                              `json:"time"`
-	TimeEpoch    int64                                               `json:"timeEpoch"`
-	HTTP         APIGatewayV2HTTPRequestContextHTTPDescription       `json:"http"`
+	RouteKey     string                                               `json:"routeKey"`
+	AccountID    string                                               `json:"accountId"`
+	Stage        string                                               `json:"stage"`
+	RequestID    string                                               `json:"requestId"`
+	Authorizer   *APIGatewayV2HTTPRequestContextAuthorizerDescription `json:"authorizer,omitempty"`
+	APIID        string                                               `json:"apiId"` // The API Gateway HTTP API Id
+	DomainName   string                                               `json:"domainName"`
+	DomainPrefix string                                               `json:"domainPrefix"`
+	Time         string                                               `json:"time"`
+	TimeEpoch    int64                                                `json:"timeEpoch"`
+	HTTP         APIGatewayV2HTTPRequestContextHTTPDescription        `json:"http"`
 }
 
 // APIGatewayV2HTTPRequestContextAuthorizerDescription contains authorizer information for the request context.

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -244,3 +244,38 @@ func TestApiGatewayV2HTTPRequestMarshaling(t *testing.T) {
 
 	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
+
+func TestApiGatewayV2HTTPRequestNoAuthorizerMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-request-no-authorizer.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent APIGatewayV2HTTPRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// validate custom authorizer context
+	authContext := inputEvent.RequestContext.Authorizer
+	if authContext != nil {
+		t.Errorf("unexpected authorizer: %v", authContext)
+	}
+
+	// validate HTTP details
+	http := inputEvent.RequestContext.HTTP
+	if http.Path != "/" {
+		t.Errorf("could not extract HTTP details: %v", http)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}

--- a/events/testdata/apigw-v2-request-no-authorizer.json
+++ b/events/testdata/apigw-v2-request-no-authorizer.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.0",
+    "routeKey": "$default",
+    "rawPath": "/",
+    "rawQueryString": "",
+    "headers": {
+        "accept": "*/*",
+        "content-length": "0",
+        "host": "aaaaaaaaaa.execute-api.us-west-2.amazonaws.com",
+        "user-agent": "curl/7.58.0",
+        "x-amzn-trace-id": "Root=1-5e9f0c65-1de4d666d4dd26aced652b6c",
+        "x-forwarded-for": "1.2.3.4",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "apiId": "aaaaaaaaaa",
+        "domainName": "aaaaaaaaaa.execute-api.us-west-2.amazonaws.com",
+        "domainPrefix": "aaaaaaaaaa",
+        "http": {
+            "method": "GET",
+            "path": "/",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.2.3.4",
+            "userAgent": "curl/7.58.0"
+        },
+        "requestId": "LV7fzho-PHcEJPw=",
+        "routeKey": "$default",
+        "stage": "$default",
+        "time": "21/Apr/2020:15:08:21 +0000",
+        "timeEpoch": 1587481701067
+    },
+    "isBase64Encoded": false
+}


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws/aws-lambda-go/issues/284.

*Description of changes:*
When testing with a minimal (`GET /`) HTTP request through an API Gateway v2 API some fields are optional and should be tagged with `omitempty`:
* `cookies`
* `queryStringParameters`
* `pathParameters`
* `stageVariables`
* `body`
* `requestContext.authorizer`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
