### PR TITLE
S3 size is optional

### DIFF
--- a/events/s3.go
+++ b/events/s3.go
@@ -47,7 +47,7 @@ type S3Bucket struct {
 
 type S3Object struct {
 	Key           string `json:"key"`
-	Size          int64  `json:"size"`
+	Size          int64  `json:"size,omitempty"`
 	URLDecodedKey string `json:"urlDecodedKey"`
 	VersionID     string `json:"versionId"`
 	ETag          string `json:"eTag"`


### PR DESCRIPTION
The `size` field can be empty. It just so happens marshaling uses Go's default which is `0`, so this doesn't show up as an error. But if you inspect the payload it can be empty.

Though not directly of concern to the go lib, without this it is causing https://github.com/LegNeato/aws-lambda-events/issues/11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
