### PR TITLE
Support setting an optional base context for functions.

### DIFF
--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -67,10 +67,12 @@ func StartHandlerWithContext(ctx context.Context, handler Handler) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = rpc.Register(NewFunctionWithContext(ctx, handler))
-	if err != nil {
+
+	fn := NewFunction(handler).withContext(ctx)
+	if err := rpc.Register(fn); err != nil {
 		log.Fatal("failed to register handler function")
 	}
+
 	rpc.Accept(lis)
 	log.Fatal("accept should not have returned")
 }

--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -3,6 +3,7 @@
 package lambda
 
 import (
+	"context"
 	"log"
 	"net"
 	"net/rpc"
@@ -37,8 +38,12 @@ import (
 // Where "TIn" and "TOut" are types compatible with the "encoding/json" standard library.
 // See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves
 func Start(handler interface{}) {
-	wrappedHandler := NewHandler(handler)
-	StartHandler(wrappedHandler)
+	StartWithContext(context.Background(), handler)
+}
+
+// StartWithContext is the same as Start except sets the base context for the function.
+func StartWithContext(ctx context.Context, handler interface{}) {
+	StartHandlerWithContext(ctx, NewHandler(handler))
 }
 
 // StartHandler takes in a Handler wrapper interface which can be implemented either by a
@@ -48,12 +53,21 @@ func Start(handler interface{}) {
 //
 //  func Invoke(context.Context, []byte) ([]byte, error)
 func StartHandler(handler Handler) {
+	StartHandlerWithContext(context.Background(), handler)
+}
+
+// StartHandlerWithContext is the same as StartHandler except sets the base context for the function.
+//
+// Handler implementation requires a single "Invoke()" function:
+//
+//  func Invoke(context.Context, []byte) ([]byte, error)
+func StartHandlerWithContext(ctx context.Context, handler Handler) {
 	port := os.Getenv("_LAMBDA_SERVER_PORT")
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = rpc.Register(NewFunction(handler))
+	err = rpc.Register(NewFunctionWithContext(ctx, handler))
 	if err != nil {
 		log.Fatal("failed to register handler function")
 	}

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -16,11 +16,29 @@ import (
 // Function struct which wrap the Handler
 type Function struct {
 	handler Handler
+	context context.Context
 }
 
 // NewFunction which creates a Function with a given Handler
 func NewFunction(handler Handler) *Function {
 	return &Function{handler: handler}
+}
+
+// NewFunctionWithContext which creates a Function with a given Handler and sets the base Context.
+func NewFunctionWithContext(ctx context.Context, handler Handler) *Function {
+	return &Function{
+		context: ctx,
+		handler: handler,
+	}
+}
+
+// Context returns the base context used for the fn.
+func (fn *Function) Context() context.Context {
+	if fn.context == nil {
+		return context.Background()
+	}
+
+	return fn.context
 }
 
 // Ping method which given a PingRequest and a PingResponse parses the PingResponse
@@ -44,7 +62,7 @@ func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.Invok
 	}()
 
 	deadline := time.Unix(req.Deadline.Seconds, req.Deadline.Nanos).UTC()
-	invokeContext, cancel := context.WithDeadline(context.Background(), deadline)
+	invokeContext, cancel := context.WithDeadline(fn.Context(), deadline)
 	defer cancel()
 
 	lc := &lambdacontext.LambdaContext{

--- a/lambda/function_test.go
+++ b/lambda/function_test.go
@@ -60,17 +60,15 @@ func TestInvoke(t *testing.T) {
 
 func TestInvokeWithContext(t *testing.T) {
 	key := struct{}{}
-	srv := &Function{
-		handler: testWrapperHandler(
-			func(ctx context.Context, input []byte) (interface{}, error) {
-				assert.Equal(t, "dummy", ctx.Value(key))
-				if deadline, ok := ctx.Deadline(); ok {
-					return deadline.UnixNano(), nil
-				}
-				return nil, errors.New("!?!?!?!?!")
-			}),
-		context: context.WithValue(context.Background(), key, "dummy"),
-	}
+	srv := NewFunction(testWrapperHandler(
+		func(ctx context.Context, input []byte) (interface{}, error) {
+			assert.Equal(t, "dummy", ctx.Value(key))
+			if deadline, ok := ctx.Deadline(); ok {
+				return deadline.UnixNano(), nil
+			}
+			return nil, errors.New("!?!?!?!?!")
+		}))
+	srv = srv.withContext(context.WithValue(context.Background(), key, "dummy"))
 	deadline := time.Now()
 	var response messages.InvokeResponse
 	err := srv.Invoke(&messages.InvokeRequest{


### PR DESCRIPTION
*Issue #, if available:* 

n/a

---
*Description of changes:* 

Adds support for setting a base context to be given to functions that take context as their first argument. Current implementation is to provide a `context.Background()`. This implements a similar feature as seen in `net/http` where a `http.Server` can be given a `BaseContext` function which returns a `context.Context` to be given to all http requests: https://golang.org/src/net/http/server.go#L2572

This avoids the need for injecting context values into the context before a function is called.

This is a non breaking API change as new explicit methods have been added to support passing in a base context.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.