### PR TITLE
Add SNSMessageAttribute type

### DIFF
--- a/events/sns.go
+++ b/events/sns.go
@@ -18,15 +18,20 @@ type SNSEventRecord struct {
 }
 
 type SNSEntity struct {
-	Signature         string                 `json:"Signature"`
-	MessageID         string                 `json:"MessageId"`
-	Type              string                 `json:"Type"`
-	TopicArn          string                 `json:"TopicArn"`
-	MessageAttributes map[string]interface{} `json:"MessageAttributes"`
-	SignatureVersion  string                 `json:"SignatureVersion"`
-	Timestamp         time.Time              `json:"Timestamp"`
-	SigningCertURL    string                 `json:"SigningCertUrl"`
-	Message           string                 `json:"Message"`
-	UnsubscribeURL    string                 `json:"UnsubscribeUrl"`
-	Subject           string                 `json:"Subject"`
+	Signature         string                         `json:"Signature"`
+	MessageID         string                         `json:"MessageId"`
+	Type              string                         `json:"Type"`
+	TopicArn          string                         `json:"TopicArn"`
+	MessageAttributes map[string]SNSMessageAttribute `json:"MessageAttributes"`
+	SignatureVersion  string                         `json:"SignatureVersion"`
+	Timestamp         time.Time                      `json:"Timestamp"`
+	SigningCertURL    string                         `json:"SigningCertUrl"`
+	Message           string                         `json:"Message"`
+	UnsubscribeURL    string                         `json:"UnsubscribeUrl"`
+	Subject           string                         `json:"Subject"`
+}
+
+type SNSMessageAttribute struct {
+	Type  string `json:"Type"`
+	Value string `json:"Value"`
 }


### PR DESCRIPTION
Implements `SNSMessageAttribute` which was inspired by the [SQSMessageAttribute](https://github.com/aws/aws-lambda-go/blob/master/events/sqs.go#L22).

Since this is a breaking change I'm not expecting it to get merged but I figured I'd submit it anyhow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
