### PR TITLE
Allow non-string value claims in APIGatewayV2HTTPRequestContextAuthorizerJWTDescription

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -85,8 +85,8 @@ type APIGatewayV2HTTPRequestContextAuthorizerDescription struct {
 
 // APIGatewayV2HTTPRequestContextAuthorizerJWTDescription contains JWT authorizer information for the request context.
 type APIGatewayV2HTTPRequestContextAuthorizerJWTDescription struct {
-	Claims map[string]string `json:"claims"`
-	Scopes []string          `json:"scopes"`
+	Claims map[string]interface{} `json:"claims"`
+	Scopes []string               `json:"scopes"`
 }
 
 // APIGatewayV2HTTPRequestContextHTTPDescription contains HTTP information for the request context.

--- a/events/testdata/apigw-v2-request.json
+++ b/events/testdata/apigw-v2-request.json
@@ -27,7 +27,8 @@
             "jwt": {
                 "claims": {
                     "claim1": "value1",
-                    "claim2": "value2"
+                    "claim2": "value2",
+                    "claim3": 3
                 },
                 "scopes": [
                     "scope1",


### PR DESCRIPTION
*Issue #, if available:*

#294 

*Description of changes:*

For some reason events from an HTTP API with a JWT Authorizer can no longer unmarshal claims.  Not sure if something upstream in API Gateway changed, but making this a map[string]interface{} allows number values like the iat or exp claims to unmarshal without error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
