### PR TITLE
Add a Runtime API client

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -94,5 +94,5 @@ func StartHandlerWithContext(ctx context.Context, handler Handler) {
 		}
 		keys = append(keys, start.env)
 	}
-	log.Fatalf("Could not find expected environment variable %s. Are you sure you're running this on AWS Lambda?", keys)
+	log.Fatalf("could not find expected AWS Lambda environment variables %s", keys)
 }

--- a/lambda/entry_test.go
+++ b/lambda/entry_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
+package lambda
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/rpc"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/lambda/messages"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartRuntimeAPIWithContext(t *testing.T) {
+	server, _ := runtimeAPIServer("null", 1) // serve a single invoke, and then cause an internal error
+	expected := "expected"
+	actual := "unexpected"
+
+	os.Setenv("AWS_LAMBDA_RUNTIME_API", strings.Split(server.URL, "://")[1])
+	defer os.Unsetenv("AWS_LAMBDA_RUNTIME_API")
+	logFatalf = func(format string, v ...interface{}) {}
+	defer func() { logFatalf = log.Fatalf }()
+
+	StartWithContext(context.WithValue(context.Background(), "key", expected), func(ctx context.Context) error {
+		actual, _ = ctx.Value("key").(string)
+		return nil
+	})
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestStartRPCWithContext(t *testing.T) {
+	expected := "expected"
+	actual := "unexpected"
+	port := getFreeTCPPort()
+	os.Setenv("_LAMBDA_SERVER_PORT", fmt.Sprintf("%d", port))
+	defer os.Unsetenv("_LAMBDA_SERVER_PORT")
+	go StartWithContext(context.WithValue(context.Background(), "key", expected), func(ctx context.Context) error {
+		actual, _ = ctx.Value("key").(string)
+		return nil
+	})
+
+	var client *rpc.Client
+	var pingResponse messages.PingResponse
+	var invokeResponse messages.InvokeResponse
+	var err error
+	for {
+		client, err = rpc.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+		if err != nil {
+			continue
+		}
+		break
+	}
+	for {
+		if err := client.Call("Function.Ping", &messages.PingRequest{}, &pingResponse); err != nil {
+			continue
+		}
+		break
+	}
+	if err := client.Call("Function.Invoke", &messages.InvokeRequest{}, &invokeResponse); err != nil {
+		t.Logf("error invoking function: %v", err)
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func getFreeTCPPort() int {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatal("getFreeTCPPort failed: ", err)
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func TestStartNotInLambda(t *testing.T) {
+	actual := "unexpected"
+	logFatalf = func(format string, v ...interface{}) {
+		actual = fmt.Sprintf(format, v...)
+	}
+
+	Start(func() error { return nil })
+	assert.Equal(t, "expected AWS Lambda environment variables [_LAMBDA_SERVER_PORT AWS_LAMBDA_RUNTIME_API] are not defined", actual)
+}

--- a/lambda/errors.go
+++ b/lambda/errors.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
+package lambda
+
+import (
+	"reflect"
+
+	"github.com/aws/aws-lambda-go/lambda/messages"
+)
+
+func getErrorType(err interface{}) string {
+	errorType := reflect.TypeOf(err)
+	if errorType.Kind() == reflect.Ptr {
+		return errorType.Elem().Name()
+	}
+	return errorType.Name()
+}
+
+func lambdaErrorResponse(invokeError error) *messages.InvokeResponse_Error {
+	var errorName string
+	if errorType := reflect.TypeOf(invokeError); errorType.Kind() == reflect.Ptr {
+		errorName = errorType.Elem().Name()
+	} else {
+		errorName = errorType.Name()
+	}
+	return &messages.InvokeResponse_Error{
+		Message: invokeError.Error(),
+		Type:    errorName,
+	}
+}
+
+func lambdaPanicResponse(err interface{}) *messages.InvokeResponse_Error {
+	panicInfo := getPanicInfo(err)
+	return &messages.InvokeResponse_Error{
+		Message:    panicInfo.Message,
+		Type:       getErrorType(err),
+		StackTrace: panicInfo.StackTrace,
+		ShouldExit: true,
+	}
+}

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/aws/aws-lambda-go/lambda/messages"
@@ -34,13 +33,7 @@ func (fn *Function) Ping(req *messages.PingRequest, response *messages.PingRespo
 func (fn *Function) Invoke(req *messages.InvokeRequest, response *messages.InvokeResponse) error {
 	defer func() {
 		if err := recover(); err != nil {
-			panicInfo := getPanicInfo(err)
-			response.Error = &messages.InvokeResponse_Error{
-				Message:    panicInfo.Message,
-				Type:       getErrorType(err),
-				StackTrace: panicInfo.StackTrace,
-				ShouldExit: true,
-			}
+			response.Error = lambdaPanicResponse(err)
 		}
 	}()
 
@@ -98,25 +91,4 @@ func (fn *Function) withContext(ctx context.Context) *Function {
 	fn2.ctx = ctx
 
 	return fn2
-}
-
-func getErrorType(err interface{}) string {
-	errorType := reflect.TypeOf(err)
-	if errorType.Kind() == reflect.Ptr {
-		return errorType.Elem().Name()
-	}
-	return errorType.Name()
-}
-
-func lambdaErrorResponse(invokeError error) *messages.InvokeResponse_Error {
-	var errorName string
-	if errorType := reflect.TypeOf(invokeError); errorType.Kind() == reflect.Ptr {
-		errorName = errorType.Elem().Name()
-	} else {
-		errorName = errorType.Name()
-	}
-	return &messages.InvokeResponse_Error{
-		Message: invokeError.Error(),
-		Type:    errorName,
-	}
 }

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -207,7 +207,6 @@ func TestInvalidJsonInput(t *testing.T) {
 	lambdaHandler := NewHandler(func(s string) error { return nil })
 	_, err := lambdaHandler.Invoke(context.TODO(), []byte(`{"invalid json`))
 	assert.Equal(t, "unexpected end of JSON input", err.Error())
-
 }
 
 func TestHandlerTrace(t *testing.T) {

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -17,7 +17,7 @@ const (
 	nsPerMS                  = int64(time.Millisecond / time.Nanosecond)
 )
 
-// startRuntimeAPILoop will return an error if handling a particualr invoke resulted in a non-recoverable error
+// startRuntimeAPILoop will return an error if handling a particular invoke resulted in a non-recoverable error
 func startRuntimeAPILoop(api string, handler Handler) error {
 	client := newRuntimeAPIClient(api)
 	function := NewFunction(handler)

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -3,6 +3,7 @@
 package lambda
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -18,9 +19,9 @@ const (
 )
 
 // startRuntimeAPILoop will return an error if handling a particular invoke resulted in a non-recoverable error
-func startRuntimeAPILoop(api string, handler Handler) error {
+func startRuntimeAPILoop(ctx context.Context, api string, handler Handler) error {
 	client := newRuntimeAPIClient(api)
-	function := NewFunction(handler)
+	function := NewFunction(handler).withContext(ctx)
 	for {
 		invoke, err := client.next()
 		if err != nil {

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -19,7 +19,7 @@ const (
 
 // startRuntimeAPILoop will return an error if handling a particualr invoke resulted in a non-recoverable error
 func startRuntimeAPILoop(api string, handler Handler) error {
-	client := New(api)
+	client := newRuntimeAPIClient(api)
 	function := NewFunction(handler)
 	for {
 		invoke, err := client.next()

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
+package lambda
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda/messages"
+)
+
+const (
+	serializationErrorFormat = `{"errorType": "Runtime.SerializationError", "errorMessage": "%s"}`
+	msPerS                   = int64(time.Second / time.Millisecond)
+	nsPerMS                  = int64(time.Millisecond / time.Nanosecond)
+)
+
+// startRuntimeAPILoop will return an error if handling a particualr invoke resulted in a non-recoverable error
+func startRuntimeAPILoop(api string, handler Handler) error {
+	client := New(api)
+	function := NewFunction(handler)
+	for {
+		invoke, err := client.next()
+		if err != nil {
+			return err
+		}
+
+		err = handleInvoke(invoke, function)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// handleInvoke returns an error if the function panics, or some other non-recoverable error occurred
+func handleInvoke(invoke *invoke, function *Function) error {
+	functionRequest, err := convertInvokeRequest(invoke)
+	if err != nil {
+		return fmt.Errorf("unexpected error occured when parsing the invoke: %v", err)
+	}
+
+	functionResponse := &messages.InvokeResponse{}
+	if err := function.Invoke(functionRequest, functionResponse); err != nil {
+		return fmt.Errorf("unexpected error occured when invoking the handler: %v", err)
+	}
+
+	if functionResponse.Error != nil {
+		payload := safeMarshal(functionResponse.Error)
+		if err := invoke.failure(payload, hontentTypeJSON); err != nil {
+			return fmt.Errorf("unexpected error occured when sending the function error to the API: %v", err)
+		}
+		if functionResponse.Error.ShouldExit {
+			return fmt.Errorf("calling the handler function resulted in a panic, the process should exit")
+		}
+		return nil
+	}
+
+	if err := invoke.success(functionResponse.Payload, hontentTypeJSON); err != nil {
+		return fmt.Errorf("unexpected error occured when sending the function functionResponse to the API: %v", err)
+	}
+
+	return nil
+}
+
+// convertInvokeRequest converts an invoke from the Runtime API, and unpacks it to be compatible with the shape of a `lambda.Function` InvokeRequest.
+func convertInvokeRequest(invoke *invoke) (*messages.InvokeRequest, error) {
+	deadlineEpochMS, err := strconv.ParseInt(invoke.headers.Get(headerDeadlineMS), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse contents of header: %s", headerDeadlineMS)
+	}
+	deadlineS := deadlineEpochMS / msPerS
+	deadlineNS := (deadlineEpochMS % msPerS) * nsPerMS
+
+	res := &messages.InvokeRequest{
+		InvokedFunctionArn: invoke.headers.Get(headerInvokedFunctionARN),
+		XAmznTraceId:       invoke.headers.Get(headerTraceID),
+		Deadline: messages.InvokeRequest_Timestamp{
+			Seconds: deadlineS,
+			Nanos:   deadlineNS,
+		},
+		Payload: invoke.payload,
+	}
+
+	clientContextJSON := invoke.headers.Get(headerClientContext)
+	if clientContextJSON != "" {
+		res.ClientContext = []byte(clientContextJSON)
+	}
+
+	cognitoIdentityJSON := invoke.headers.Get(headerCognitoIdentity)
+	if cognitoIdentityJSON != "" {
+		if err := json.Unmarshal([]byte(invoke.headers.Get(headerCognitoIdentity)), res); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cognito identity json: %v", err)
+		}
+	}
+
+	return res, nil
+}
+
+func safeMarshal(v interface{}) []byte {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return []byte(fmt.Sprintf(serializationErrorFormat, err.Error()))
+	}
+	return payload
+}

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -48,7 +48,7 @@ func handleInvoke(invoke *invoke, function *Function) error {
 
 	if functionResponse.Error != nil {
 		payload := safeMarshal(functionResponse.Error)
-		if err := invoke.failure(payload, hontentTypeJSON); err != nil {
+		if err := invoke.failure(payload, contentTypeJSON); err != nil {
 			return fmt.Errorf("unexpected error occured when sending the function error to the API: %v", err)
 		}
 		if functionResponse.Error.ShouldExit {
@@ -57,7 +57,7 @@ func handleInvoke(invoke *invoke, function *Function) error {
 		return nil
 	}
 
-	if err := invoke.success(functionResponse.Payload, hontentTypeJSON); err != nil {
+	if err := invoke.success(functionResponse.Payload, contentTypeJSON); err != nil {
 		return fmt.Errorf("unexpected error occured when sending the function functionResponse to the API: %v", err)
 	}
 

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
 package lambda
 
 import (

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -1,0 +1,106 @@
+package lambda
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFatalErrors(t *testing.T) {
+	ts, record := runtimeAPIServer(``, 100)
+	defer ts.Close()
+	handler := NewHandler(func() error {
+		panic(errors.New("a fatal error"))
+	})
+	endpoint := strings.Split(ts.URL, "://")[1]
+	expectedErrorMessage := "calling the handler function resulted in a panic, the process should exit"
+	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedErrorMessage)
+	assert.Equal(t, 1, record.nGets)
+	assert.Equal(t, 1, record.nGets)
+
+}
+
+func TestRuntimeAPILoop(t *testing.T) {
+	nInvokes := 10
+
+	ts, record := runtimeAPIServer(``, nInvokes)
+	defer ts.Close()
+
+	n := 0
+	handler := NewHandler(func() (string, error) {
+		n += 1
+		if n%3 == 0 {
+			return "", errors.New("error time!")
+		}
+		return "Hello!", nil
+	})
+	endpoint := strings.Split(ts.URL, "://")[1]
+	expectedError := fmt.Sprintf("failed to GET http://%s/2018-06-01/runtime/invocation/next: got unexpected status code: 410", endpoint)
+	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedError)
+	assert.Equal(t, nInvokes+1, record.nGets)
+	assert.Equal(t, nInvokes, record.nPosts)
+}
+
+func TestReadPayload(t *testing.T) {
+	ts, record := runtimeAPIServer(`{"message": "I am craving tacos"}`, 1)
+	defer ts.Close()
+
+	handler := NewHandler(func(event struct{ Message string }) (string, error) {
+		length := utf8.RuneCountInString(event.Message)
+		reversed := make([]rune, length)
+		for i, v := range event.Message {
+			reversed[length-i-1] = v
+		}
+		return string(reversed), nil
+	})
+	endpoint := strings.Split(ts.URL, "://")[1]
+	_ = startRuntimeAPILoop(endpoint, handler)
+	assert.Equal(t, `"socat gnivarc ma I"`, string(record.responses[0]))
+
+}
+
+type requestRecord struct {
+	nGets     int
+	nPosts    int
+	responses [][]byte
+}
+
+func runtimeAPIServer(eventPayload string, failAfter int) (*httptest.Server, *requestRecord) {
+	numInvokesRequested := 0
+	record := &requestRecord{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			record.nGets++
+			numInvokesRequested++
+			if numInvokesRequested > failAfter {
+				w.WriteHeader(http.StatusGone)
+				_, _ = w.Write([]byte("END THE TEST!"))
+			}
+			w.Header().Add(string(headerAWSRequestID), "dummy-request-id")
+			w.Header().Add(string(headerDeadlineMS), "22")
+			w.Header().Add(string(headerInvokedFunctionARN), "anarn")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(eventPayload))
+		case http.MethodPost:
+			record.nPosts++
+			response := bytes.NewBuffer(nil)
+			_, _ = io.Copy(response, r.Body)
+			r.Body.Close()
+			w.WriteHeader(http.StatusAccepted)
+			record.responses = append(record.responses, response.Bytes())
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+
+	return ts, record
+}

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -4,6 +4,7 @@ package lambda
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -24,7 +25,7 @@ func TestFatalErrors(t *testing.T) {
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedErrorMessage := "calling the handler function resulted in a panic, the process should exit"
-	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedErrorMessage)
+	assert.EqualError(t, startRuntimeAPILoop(context.Background(), endpoint, handler), expectedErrorMessage)
 	assert.Equal(t, 1, record.nGets)
 	assert.Equal(t, 1, record.nGets)
 }
@@ -45,7 +46,7 @@ func TestRuntimeAPILoop(t *testing.T) {
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedError := fmt.Sprintf("failed to GET http://%s/2018-06-01/runtime/invocation/next: got unexpected status code: 410", endpoint)
-	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedError)
+	assert.EqualError(t, startRuntimeAPILoop(context.Background(), endpoint, handler), expectedError)
 	assert.Equal(t, nInvokes+1, record.nGets)
 	assert.Equal(t, nInvokes, record.nPosts)
 }
@@ -63,7 +64,7 @@ func TestReadPayload(t *testing.T) {
 		return string(reversed), nil
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
-	_ = startRuntimeAPILoop(endpoint, handler)
+	_ = startRuntimeAPILoop(context.Background(), endpoint, handler)
 	assert.Equal(t, `"socat gnivarc ma I"`, string(record.responses[0]))
 
 }

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -96,7 +96,7 @@ func runtimeAPIServer(eventPayload string, failAfter int) (*httptest.Server, *re
 			record.nPosts++
 			response := bytes.NewBuffer(nil)
 			_, _ = io.Copy(response, r.Body)
-			r.Body.Close()
+			_ = r.Body.Close()
 			w.WriteHeader(http.StatusAccepted)
 			record.responses = append(record.responses, response.Bytes())
 		default:

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -27,7 +27,6 @@ func TestFatalErrors(t *testing.T) {
 	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedErrorMessage)
 	assert.Equal(t, 1, record.nGets)
 	assert.Equal(t, 1, record.nGets)
-
 }
 
 func TestRuntimeAPILoop(t *testing.T) {

--- a/lambda/messages/messages.go
+++ b/lambda/messages/messages.go
@@ -30,10 +30,10 @@ type InvokeResponse struct {
 }
 
 type InvokeResponse_Error struct {
-	Message    string
-	Type       string
-	StackTrace []*InvokeResponse_Error_StackFrame
-	ShouldExit bool
+	Message    string                             `json:"errorMessage"`
+	Type       string                             `json:"errorType"`
+	StackTrace []*InvokeResponse_Error_StackFrame `json:"stackTrace,omitempty"`
+	ShouldExit bool                               `json:"-"`
 }
 
 type InvokeResponse_Error_StackFrame struct {

--- a/lambda/rpc.go
+++ b/lambda/rpc.go
@@ -5,6 +5,7 @@
 package lambda
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net"
@@ -18,12 +19,12 @@ func init() {
 	rpcStartFunction.f = startFunctionRPC
 }
 
-func startFunctionRPC(port string, handler Handler) error {
+func startFunctionRPC(ctx context.Context, port string, handler Handler) error {
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = rpc.Register(NewFunction(handler))
+	err = rpc.Register(NewFunction(handler).withContext(ctx))
 	if err != nil {
 		log.Fatal("failed to register handler function")
 	}

--- a/lambda/rpc.go
+++ b/lambda/rpc.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
+// +build !lambda.norpc
+
+package lambda
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/rpc"
+)
+
+func init() {
+	// Register `startFunctionRPC` to be run if the _LAMBDA_SERVER_PORT environment variable is set.
+	// This happens when the runtime for the function is configured as `go1.x`.
+	// The value of the environment variable will be passed as the first argument to `startFunctionRPC`.
+	rpcStartFunction.f = startFunctionRPC
+}
+
+func startFunctionRPC(port string, handler Handler) error {
+	lis, err := net.Listen("tcp", "localhost:"+port)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = rpc.Register(NewFunction(handler))
+	if err != nil {
+		log.Fatal("failed to register handler function")
+	}
+	rpc.Accept(lis)
+	return errors.New("accept should not have returned")
+}

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"runtime"
 )
@@ -79,7 +80,11 @@ func (c *runtimeAPIClient) next() (*invoke, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the next invoke: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("runtime API client failed to close %s response body: %v", url, err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to GET %s: got unexpected status code: %d", url, resp.StatusCode)
@@ -111,7 +116,11 @@ func (c *runtimeAPIClient) post(url string, payload []byte, contentType string) 
 	if err != nil {
 		return fmt.Errorf("failed to POST to %s: %v", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("runtime API client failed to close %s response body: %v", url, err)
+		}
+	}()
 
 	if 202 != resp.StatusCode {
 		return fmt.Errorf("failed to POST to %s: got unexpected status code: %d", url, resp.StatusCode)

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -20,7 +20,7 @@ const (
 	headerCognitoIdentity    = "Lambda-Runtime-Cognito-Identity"
 	headerClientContext      = "Lambda-Runtime-Client-Context"
 	headerInvokedFunctionARN = "Lambda-Runtime-Invoked-Function-Arn"
-	hontentTypeJSON          = "application/json"
+	contentTypeJSON          = "application/json"
 	apiVersion               = "2018-06-01"
 )
 

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -1,0 +1,126 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+//
+// Runtime API documentation: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
+
+package lambda
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"runtime"
+)
+
+const (
+	headerAWSRequestID       = "Lambda-Runtime-Aws-Request-Id"
+	headerDeadlineMS         = "Lambda-Runtime-Deadline-Ms"
+	headerTraceID            = "Lambda-Runtime-Trace-Id"
+	headerCognitoIdentity    = "Lambda-Runtime-Cognito-Identity"
+	headerClientContext      = "Lambda-Runtime-Client-Context"
+	headerInvokedFunctionARN = "Lambda-Runtime-Invoked-Function-Arn"
+	hontentTypeJSON          = "application/json"
+	apiVersion               = "2018-06-01"
+)
+
+type runtimeAPIClient struct {
+	baseURL    string
+	userAgent  string
+	httpClient *http.Client
+	buffer     *bytes.Buffer
+}
+
+func New(address string) *runtimeAPIClient {
+	client := &http.Client{
+		Timeout: 0, // connections to the runtime API are never expected to time out
+	}
+	endpoint := "http://" + address + "/" + apiVersion + "/runtime/invocation/"
+	userAgent := "aws-lambda-go/" + runtime.Version()
+	return &runtimeAPIClient{endpoint, userAgent, client, bytes.NewBuffer(nil)}
+}
+
+type invoke struct {
+	id      string
+	payload []byte
+	headers http.Header
+	client  *runtimeAPIClient
+}
+
+// success sends the response payload for an in-progress invocation.
+// Notes:
+//   * An invoke is not complete until next() is called again!
+func (i *invoke) success(payload []byte, contentType string) error {
+	url := i.client.baseURL + i.id + "/response"
+	return i.client.post(url, payload, contentType)
+}
+
+// failure sends the payload to the Runtime API. This marks the function's invoke as a failure.
+// Notes:
+//    * The execution of the function process continues, and is billed, until next() is called again!
+//    * A Lambda Function continues to be re-used for future invokes even after a failure.
+//      If the error is fatal (panic, unrecoverable state), exit the process immediately after calling failure()
+func (i *invoke) failure(payload []byte, contentType string) error {
+	url := i.client.baseURL + i.id + "/error"
+	return i.client.post(url, payload, contentType)
+}
+
+// next connects to the Runtime API and waits for a new invoke Request to be available.
+// Note: After a call to Done() or Error() has been made, a call to next() will complete the in-flight invoke.
+func (c *runtimeAPIClient) next() (*invoke, error) {
+	url := c.baseURL + "next"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct GET request to %s: %v", url, err)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the next invoke: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to GET %s: got unexpected status code: %d", url, resp.StatusCode)
+	}
+
+	body := bytes.NewBuffer(nil)
+	_, err = io.Copy(body, resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the invoke payload: %v", err)
+	}
+
+	return &invoke{
+		id:      resp.Header.Get(headerAWSRequestID),
+		payload: body.Bytes(),
+		headers: resp.Header,
+		client:  c,
+	}, nil
+}
+
+func (c *runtimeAPIClient) post(url string, payload []byte, contentType string) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to construct POST request to %s: %v", url, err)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to POST to %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if 202 != resp.StatusCode {
+		return fmt.Errorf("failed to POST to %s: got unexpected status code: %d", url, resp.StatusCode)
+	}
+
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	if err != nil {
+		return fmt.Errorf("something went wrong reading the POST response from %s: %v", url, err)
+	}
+
+	return nil
+}

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -31,7 +31,7 @@ type runtimeAPIClient struct {
 	buffer     *bytes.Buffer
 }
 
-func New(address string) *runtimeAPIClient {
+func newRuntimeAPIClient(address string) *runtimeAPIClient {
 	client := &http.Client{
 		Timeout: 0, // connections to the runtime API are never expected to time out
 	}

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -87,11 +87,11 @@ func TestClientDoneAndError(t *testing.T) {
 			client: client,
 		}
 		t.Run(fmt.Sprintf("happy Done with payload[%d]", i), func(t *testing.T) {
-			err := invoke.success(payload, hontentTypeJSON)
+			err := invoke.success(payload, contentTypeJSON)
 			assert.NoError(t, err)
 		})
 		t.Run(fmt.Sprintf("happy Error with payload[%d]", i), func(t *testing.T) {
-			err := invoke.failure(payload, hontentTypeJSON)
+			err := invoke.failure(payload, contentTypeJSON)
 			assert.NoError(t, err)
 		})
 	}

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -37,14 +37,14 @@ func TestClientNext(t *testing.T) {
 	defer returnsNoBody.Close()
 
 	t.Run("handles regular response", func(t *testing.T) {
-		invoke, err := New(serverAddress(returnsBody)).next()
+		invoke, err := newRuntimeAPIClient(serverAddress(returnsBody)).next()
 		require.NoError(t, err)
 		assert.Equal(t, dummyRequestID, invoke.id)
 		assert.Equal(t, dummyPayload, string(invoke.payload))
 	})
 
 	t.Run("handles no body", func(t *testing.T) {
-		invoke, err := New(serverAddress(returnsNoBody)).next()
+		invoke, err := newRuntimeAPIClient(serverAddress(returnsNoBody)).next()
 		require.NoError(t, err)
 		assert.Equal(t, dummyRequestID, invoke.id)
 		assert.Equal(t, 0, len(invoke.payload))
@@ -78,7 +78,7 @@ func TestClientDoneAndError(t *testing.T) {
 	}))
 	defer acceptsResponses.Close()
 
-	client := New(serverAddress(acceptsResponses))
+	client := newRuntimeAPIClient(serverAddress(acceptsResponses))
 	inputPayloads := [][]byte{nil, {}, []byte("hello")}
 	expectedPayloadsRecived := [][]byte{{}, {}, []byte("hello")} // nil payload expected to be read as empty bytes by the server
 	for i, payload := range inputPayloads {
@@ -100,11 +100,11 @@ func TestClientDoneAndError(t *testing.T) {
 }
 
 func TestInvalidRequestsForMalformedEndpoint(t *testing.T) {
-	_, err := New("🚨").next()
+	_, err := newRuntimeAPIClient("🚨").next()
 	require.Error(t, err)
-	err = (&invoke{client: New("🚨")}).success(nil, "")
+	err = (&invoke{client: newRuntimeAPIClient("🚨")}).success(nil, "")
 	require.Error(t, err)
-	err = (&invoke{client: New("🚨")}).failure(nil, "")
+	err = (&invoke{client: newRuntimeAPIClient("🚨")}).failure(nil, "")
 	require.Error(t, err)
 }
 
@@ -120,7 +120,7 @@ func TestStatusCodes(t *testing.T) {
 
 			defer ts.Close()
 
-			client := New(serverAddress(ts))
+			client := newRuntimeAPIClient(serverAddress(ts))
 			invoke := &invoke{id: url, client: client}
 			if i == http.StatusOK {
 				t.Run("next should not error", func(t *testing.T) {

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -1,0 +1,175 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved
+
+package lambda
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientNext(t *testing.T) {
+	dummyRequestID := "dummy-request-id"
+	dummyPayload := `{"hello": "world"}`
+
+	returnsBody := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/2018-06-01/runtime/invocation/next" {
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+		w.Header().Add(headerAWSRequestID, dummyRequestID)
+		_, _ = w.Write([]byte(dummyPayload))
+	}))
+	defer returnsBody.Close()
+
+	returnsNoBody := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/2018-06-01/runtime/invocation/next" {
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+		w.Header().Add(headerAWSRequestID, dummyRequestID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer returnsNoBody.Close()
+
+	t.Run("handles regular response", func(t *testing.T) {
+		invoke, err := New(serverAddress(returnsBody)).next()
+		require.NoError(t, err)
+		assert.Equal(t, dummyRequestID, invoke.id)
+		assert.Equal(t, dummyPayload, string(invoke.payload))
+	})
+
+	t.Run("handles no body", func(t *testing.T) {
+		invoke, err := New(serverAddress(returnsNoBody)).next()
+		require.NoError(t, err)
+		assert.Equal(t, dummyRequestID, invoke.id)
+		assert.Equal(t, 0, len(invoke.payload))
+	})
+}
+
+func TestClientDoneAndError(t *testing.T) {
+	invokeID := "theid"
+
+	var capturedErrors [][]byte
+	var capturedResponses [][]byte
+
+	acceptsResponses := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Logf("unexpected method: %s", r.Method)
+			w.WriteHeader(http.StatusNotImplemented)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/2018-06-01/runtime/invocation/%s/error", invokeID) && r.URL.Path != fmt.Sprintf("/2018-06-01/runtime/invocation/%s/response", invokeID) {
+			t.Logf("unexpected url path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := ioutil.ReadAll(r.Body)
+		if strings.HasSuffix(r.URL.Path, "/error") {
+			capturedErrors = append(capturedErrors, body)
+		} else if strings.HasSuffix(r.URL.Path, "/response") {
+			capturedResponses = append(capturedErrors, body)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer acceptsResponses.Close()
+
+	client := New(serverAddress(acceptsResponses))
+	inputPayloads := [][]byte{nil, {}, []byte("hello")}
+	expectedPayloadsRecived := [][]byte{{}, {}, []byte("hello")} // nil payload expected to be read as empty bytes by the server
+	for i, payload := range inputPayloads {
+		invoke := &invoke{
+			id:     invokeID,
+			client: client,
+		}
+		t.Run(fmt.Sprintf("happy Done with payload[%d]", i), func(t *testing.T) {
+			err := invoke.success(payload, hontentTypeJSON)
+			assert.NoError(t, err)
+		})
+		t.Run(fmt.Sprintf("happy Error with payload[%d]", i), func(t *testing.T) {
+			err := invoke.failure(payload, hontentTypeJSON)
+			assert.NoError(t, err)
+		})
+	}
+	assert.Equal(t, expectedPayloadsRecived, capturedErrors)
+	assert.Equal(t, expectedPayloadsRecived, capturedResponses)
+}
+
+func TestInvalidRequestsForMalformedEndpoint(t *testing.T) {
+	_, err := New("🚨").next()
+	require.Error(t, err)
+	err = (&invoke{client: New("🚨")}).success(nil, "")
+	require.Error(t, err)
+	err = (&invoke{client: New("🚨")}).failure(nil, "")
+	require.Error(t, err)
+}
+
+func TestStatusCodes(t *testing.T) {
+	for i := 200; i < 600; i++ {
+		t.Run(fmt.Sprintf("status: %d", i), func(t *testing.T) {
+			url := fmt.Sprintf("status-%d", i)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = ioutil.ReadAll(r.Body)
+				w.WriteHeader(i)
+			}))
+
+			defer ts.Close()
+
+			client := New(serverAddress(ts))
+			invoke := &invoke{id: url, client: client}
+			if i == http.StatusOK {
+				t.Run("next should not error", func(t *testing.T) {
+					_, err := client.next()
+					require.NoError(t, err)
+				})
+			} else {
+				t.Run("next should error", func(t *testing.T) {
+					_, err := client.next()
+					require.Error(t, err)
+					if i != 301 && i != 302 && i != 303 {
+						assert.Contains(t, err.Error(), "unexpected status code")
+						assert.Contains(t, err.Error(), fmt.Sprintf("%d", i))
+					}
+				})
+			}
+
+			if i == http.StatusAccepted {
+				t.Run("success should not error", func(t *testing.T) {
+					err := invoke.success(nil, "")
+					require.NoError(t, err)
+				})
+				t.Run("failure should not error", func(t *testing.T) {
+					err := invoke.failure(nil, "")
+					require.NoError(t, err)
+				})
+			} else {
+				t.Run("success should error", func(t *testing.T) {
+					err := invoke.success(nil, "")
+					require.Error(t, err)
+					if i != 301 && i != 302 && i != 303 {
+						assert.Contains(t, err.Error(), "unexpected status code")
+						assert.Contains(t, err.Error(), fmt.Sprintf("%d", i))
+					}
+				})
+				t.Run("failure should error", func(t *testing.T) {
+					err := invoke.failure(nil, "")
+					require.Error(t, err)
+					if i != 301 && i != 302 && i != 303 {
+						assert.Contains(t, err.Error(), "unexpected status code")
+						assert.Contains(t, err.Error(), fmt.Sprintf("%d", i))
+					}
+				})
+			}
+		})
+	}
+
+}
+
+func serverAddress(ts *httptest.Server) string {
+	return strings.Split(ts.URL, "://")[1]
+}

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -167,7 +167,6 @@ func TestStatusCodes(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func serverAddress(ts *httptest.Server) string {


### PR DESCRIPTION
*Description of changes:*

This change adds support for using the [Lambda Runtime API](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html). The effect of this, is that Lamdba Functions written in go, can be used with both the `go1.x`, and `provided`, runtimes.

Why?
* This is a future-looking change. The Runtime API is where future innovations are going to happen.
* This makes it easier to implement custom runtimes using go. Got an idea for a custom runtime? You can re-use the AWS Lambda Go programming model to get started

How to try it:
1. Compile your function as normal.
2. When creating the .zip, name the binary `bootstrap`, or place a symlink to your binary named bootstrap within the .zip
3. When creating a function, choose `provided` as the runtime

```
GOOS=linux go build -o bootstrap main.go && zip lambda.zip bootstrap
aws lambda create-function \
   ... \ # iam role, name, memory size
   --zip-file lambda.zip \
   --runtime provided \
   --handler bootstrap # can be any value, the provided runtime ignores this, and always looks for an exe named `bootstrap`
```
 
Functions build this way are still compatible with the go1.x runtime. The RPC or the Runtime API mechanism will be detected on startup using environment variables Lambda defines by default.

I've also added a build flag, that allows disabling RPC support, which may result in slightly smaller binary sizes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
