### PR TITLE
lambda: check if error type is InvokeResponse_Error

### DIFF
--- a/lambda/errors.go
+++ b/lambda/errors.go
@@ -17,6 +17,9 @@ func getErrorType(err interface{}) string {
 }
 
 func lambdaErrorResponse(invokeError error) *messages.InvokeResponse_Error {
+	if ive, ok := invokeError.(messages.InvokeResponse_Error); ok {
+		return &ive
+	}
 	var errorName string
 	if errorType := reflect.TypeOf(invokeError); errorType.Kind() == reflect.Ptr {
 		errorName = errorType.Elem().Name()
@@ -30,6 +33,9 @@ func lambdaErrorResponse(invokeError error) *messages.InvokeResponse_Error {
 }
 
 func lambdaPanicResponse(err interface{}) *messages.InvokeResponse_Error {
+	if ive, ok := err.(messages.InvokeResponse_Error); ok {
+		return &ive
+	}
 	panicInfo := getPanicInfo(err)
 	return &messages.InvokeResponse_Error{
 		Message:    panicInfo.Message,

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/lambda/handlertrace"
+	"github.com/aws/aws-lambda-go/lambda/messages"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -185,6 +186,13 @@ func TestInvokes(t *testing.T) {
 			expected: expected{`{"Number":9001}`, nil},
 			handler: func(event int) (struct{ Number int }, error) {
 				return struct{ Number int }{event}, nil
+			},
+		},
+		{
+			input:    `"Lambda"`,
+			expected: expected{"", messages.InvokeResponse_Error{Message: "message", Type: "type"}},
+			handler: func(e interface{}) (interface{}, error) {
+				return nil, messages.InvokeResponse_Error{Message: "message", Type: "type"}
 			},
 		},
 	}

--- a/lambda/messages/messages.go
+++ b/lambda/messages/messages.go
@@ -2,6 +2,8 @@
 
 package messages
 
+import "fmt"
+
 type PingRequest struct {
 }
 
@@ -34,6 +36,10 @@ type InvokeResponse_Error struct {
 	Type       string                             `json:"errorType"`
 	StackTrace []*InvokeResponse_Error_StackFrame `json:"stackTrace,omitempty"`
 	ShouldExit bool                               `json:"-"`
+}
+
+func (e InvokeResponse_Error) Error() string {
+	return fmt.Sprintf("%#v", e)
 }
 
 type InvokeResponse_Error_StackFrame struct {

--- a/lambda/panic_test.go
+++ b/lambda/panic_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-lambda-go/lambda/messages"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,6 +36,11 @@ func TestPanicFormattingIntValue(t *testing.T) {
 func TestPanicFormattingCustomError(t *testing.T) {
 	customError := &CustomError{}
 	assertPanicMessage(t, func() { panic(customError) }, customError.Error())
+}
+
+func TestPanicFormattingInvokeResponse_Error(t *testing.T) {
+	ive := &messages.InvokeResponse_Error{Message: "message", Type: "type"}
+	assertPanicMessage(t, func() { panic(ive) }, ive.Error())
 }
 
 func TestFormatFrame(t *testing.T) {


### PR DESCRIPTION
Currently, we cannot set the errorType field without creating a custom
named error type. This causes a proliferation of dummy named error types
whose only purpose is to set a text field, and limits the errorType
field to what can be expressed as an identifier.

This change checks that the panicked or returned error is if type
InvokeResponse_Error, and if so, uses it directly in the invoker's
response. InvokeResponse_Error is now updated to implement error.

Note: This is fully backwards compatible, since InvokeResponse_Error
previously did not implement the error interface.

Fixes #308.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.