### PR TITLE
Add missing request ID to context in norpc mode

### DIFF
--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -77,6 +77,7 @@ func convertInvokeRequest(invoke *invoke) (*messages.InvokeRequest, error) {
 	res := &messages.InvokeRequest{
 		InvokedFunctionArn: invoke.headers.Get(headerInvokedFunctionARN),
 		XAmznTraceId:       invoke.headers.Get(headerTraceID),
+		RequestId:          invoke.id,
 		Deadline: messages.InvokeRequest_Timestamp{
 			Seconds: deadlineS,
 			Nanos:   deadlineNS,


### PR DESCRIPTION
When self-hosting a Go lambda, the Request ID was missing from the invocation context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
