### PR TITLE
Mark HTTP v2 JWT scopes as `omitempty`

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -86,7 +86,7 @@ type APIGatewayV2HTTPRequestContextAuthorizerDescription struct {
 // APIGatewayV2HTTPRequestContextAuthorizerJWTDescription contains JWT authorizer information for the request context.
 type APIGatewayV2HTTPRequestContextAuthorizerJWTDescription struct {
 	Claims map[string]string `json:"claims"`
-	Scopes []string          `json:"scopes"`
+	Scopes []string          `json:"scopes,omitempty"`
 }
 
 // APIGatewayV2HTTPRequestContextHTTPDescription contains HTTP information for the request context.


### PR DESCRIPTION
*Issue #, if available:*
GH-317

*Description of changes:*
Mark HTTP v2 JWT scopes as `omitempty`

I observed this field as null in the wild, and others have as well:
*  https://www.jeremydaly.com/verifying-self-signed-jwt-tokens-with-aws-http-apis/
* https://dev.to/martzcodes/token-authorizers-with-apigatewayv2-tricks-apigwv1-doesn-t-want-you-to-know-41jn



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
