### PR TITLE
fix: events/codedeploy.go:16:2: SA9004 (staticcheck)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,11 @@ linters:
     - gofmt
     - errcheck
     - deadcode
-    - gosimple 
+    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck 
+    - structcheck
     - typecheck
     - unused
     - varcheck
@@ -26,9 +26,3 @@ run:
     # 	CodeBuildPhaseTypeSubmitted       CodeBuildPhaseType = "SUBMITTED"
     # 	^
     - events/codebuild.go
-
-    # FIXME
-    # events/codedeploy.go:16:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
-    #	CodeDeployDeploymentStateFailure CodeDeployDeploymentState = "FAILURE"
-    #	^
-    - events/codedeploy.go

--- a/events/codedeploy.go
+++ b/events/codedeploy.go
@@ -14,10 +14,10 @@ type CodeDeployDeploymentState string
 
 const (
 	CodeDeployDeploymentStateFailure CodeDeployDeploymentState = "FAILURE"
-	CodeDeployDeploymentStateReady                             = "READY"
-	CodeDeployDeploymentStateStart                             = "START"
-	CodeDeployDeploymentStateStop                              = "STOP"
-	CodeDeployDeploymentStateSuccess                           = "SUCCESS"
+	CodeDeployDeploymentStateReady   CodeDeployDeploymentState = "READY"
+	CodeDeployDeploymentStateStart   CodeDeployDeploymentState = "START"
+	CodeDeployDeploymentStateStop    CodeDeployDeploymentState = "STOP"
+	CodeDeployDeploymentStateSuccess CodeDeployDeploymentState = "SUCCESS"
 )
 
 // CodeDeployEvent is documented at:


### PR DESCRIPTION
*Issue #, if available:*

It fixes the following staticcheck warning.

```
events/codedeploy.go:16:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
	CodeDeployDeploymentStateFailure CodeDeployDeploymentState = "FAILURE"
	^
```

The warning is shown because CodeDeployDeploymentState constants have unexpected type.

```go
package main

import (
	"fmt"

	"github.com/aws/aws-lambda-go/events"
)

func main() {
	fmt.Printf("%10[1]s: %[1]T\n", events.CodeDeployDeploymentStateFailure)
	fmt.Printf("%10[1]s: %[1]T\n", events.CodeDeployDeploymentStateReady)
	fmt.Printf("%10[1]s: %[1]T\n", events.CodeDeployDeploymentStateStart)
	fmt.Printf("%10[1]s: %[1]T\n", events.CodeDeployDeploymentStateStop)
	fmt.Printf("%10[1]s: %[1]T\n", events.CodeDeployDeploymentStateSuccess)
}
```

got:

```
   FAILURE: events.CodeDeployDeploymentState
     READY: string
     START: string
      STOP: string
   SUCCESS: string
```

want:

```
   FAILURE: events.CodeDeployDeploymentState
     READY: events.CodeDeployDeploymentState
     START: events.CodeDeployDeploymentState
      STOP: events.CodeDeployDeploymentState
   SUCCESS: events.CodeDeployDeploymentState
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
