### PR TITLE
fix: staticcheck warnings in events/codebuild.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,11 @@ linters:
     - gofmt
     - errcheck
     - deadcode
-    - gosimple 
+    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck 
+    - structcheck
     - typecheck
     - unused
     - varcheck
@@ -17,15 +17,6 @@ run:
   skip-files:
     # These were code-generated, and cannot be changed without breaking RPC compatability.
     - lambda/messages/*.go
-
-    # FIXME
-    # events/codebuild.go:18:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
-    # 	CodeBuildPhaseStatusFailed     CodeBuildPhaseStatus = "FAILED"
-    # 	^
-    # events/codebuild.go:31:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
-    # 	CodeBuildPhaseTypeSubmitted       CodeBuildPhaseType = "SUBMITTED"
-    # 	^
-    - events/codebuild.go
 
     # FIXME
     # events/codedeploy.go:16:2: SA9004: only the first constant in this group has an explicit type (staticcheck)

--- a/events/codebuild.go
+++ b/events/codebuild.go
@@ -16,12 +16,12 @@ type CodeBuildPhaseStatus string
 
 const (
 	CodeBuildPhaseStatusFailed     CodeBuildPhaseStatus = "FAILED"
-	CodeBuildPhaseStatusFault                           = "FAULT"
-	CodeBuildPhaseStatusInProgress                      = "IN_PROGRESS"
-	CodeBuildPhaseStatusQueued                          = "QUEUED"
-	CodeBuildPhaseStatusStopped                         = "STOPPED"
-	CodeBuildPhaseStatusSucceeded                       = "SUCCEEDED"
-	CodeBuildPhaseStatusTimedOut                        = "TIMED_OUT"
+	CodeBuildPhaseStatusFault      CodeBuildPhaseStatus = "FAULT"
+	CodeBuildPhaseStatusInProgress CodeBuildPhaseStatus = "IN_PROGRESS"
+	CodeBuildPhaseStatusQueued     CodeBuildPhaseStatus = "QUEUED"
+	CodeBuildPhaseStatusStopped    CodeBuildPhaseStatus = "STOPPED"
+	CodeBuildPhaseStatusSucceeded  CodeBuildPhaseStatus = "SUCCEEDED"
+	CodeBuildPhaseStatusTimedOut   CodeBuildPhaseStatus = "TIMED_OUT"
 )
 
 // CodeBuildPhaseType represents the type of the code build phase (i.e. submitted, install)
@@ -29,16 +29,16 @@ type CodeBuildPhaseType string
 
 const (
 	CodeBuildPhaseTypeSubmitted       CodeBuildPhaseType = "SUBMITTED"
-	CodeBuildPhaseTypeQueued                             = "QUEUED"
-	CodeBuildPhaseTypeProvisioning                       = "PROVISIONING"
-	CodeBuildPhaseTypeDownloadSource                     = "DOWNLOAD_SOURCE"
-	CodeBuildPhaseTypeInstall                            = "INSTALL"
-	CodeBuildPhaseTypePreBuild                           = "PRE_BUILD"
-	CodeBuildPhaseTypeBuild                              = "BUILD"
-	CodeBuildPhaseTypePostBuild                          = "POST_BUILD"
-	CodeBuildPhaseTypeUploadArtifacts                    = "UPLOAD_ARTIFACTS"
-	CodeBuildPhaseTypeFinalizing                         = "FINALIZING"
-	CodeBuildPhaseTypeCompleted                          = "COMPLETED"
+	CodeBuildPhaseTypeQueued          CodeBuildPhaseType = "QUEUED"
+	CodeBuildPhaseTypeProvisioning    CodeBuildPhaseType = "PROVISIONING"
+	CodeBuildPhaseTypeDownloadSource  CodeBuildPhaseType = "DOWNLOAD_SOURCE"
+	CodeBuildPhaseTypeInstall         CodeBuildPhaseType = "INSTALL"
+	CodeBuildPhaseTypePreBuild        CodeBuildPhaseType = "PRE_BUILD"
+	CodeBuildPhaseTypeBuild           CodeBuildPhaseType = "BUILD"
+	CodeBuildPhaseTypePostBuild       CodeBuildPhaseType = "POST_BUILD"
+	CodeBuildPhaseTypeUploadArtifacts CodeBuildPhaseType = "UPLOAD_ARTIFACTS"
+	CodeBuildPhaseTypeFinalizing      CodeBuildPhaseType = "FINALIZING"
+	CodeBuildPhaseTypeCompleted       CodeBuildPhaseType = "COMPLETED"
 )
 
 // CodeBuildEvent is documented at:
@@ -81,12 +81,12 @@ type CodeBuildEventDetail struct {
 	ProjectName           string                              `json:"project-name"`
 	BuildID               string                              `json:"build-id"`
 	AdditionalInformation CodeBuildEventAdditionalInformation `json:"additional-information"`
-	CurrentPhase          CodeBuildPhaseStatus                `json:"current-phase"`
+	CurrentPhase          CodeBuildPhaseType                  `json:"current-phase"`
 	CurrentPhaseContext   string                              `json:"current-phase-context"`
 	Version               string                              `json:"version"`
 
 	CompletedPhaseStatus   CodeBuildPhaseStatus `json:"completed-phase-status"`
-	CompletedPhase         CodeBuildPhaseStatus `json:"completed-phase"`
+	CompletedPhase         CodeBuildPhaseType   `json:"completed-phase"`
 	CompletedPhaseContext  string               `json:"completed-phase-context"`
 	CompletedPhaseDuration DurationSeconds      `json:"completed-phase-duration-seconds"`
 	CompletedPhaseStart    CodeBuildTime        `json:"completed-phase-start"`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

it fixes the following warnings.

```
    # events/codebuild.go:18:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
    # 	CodeBuildPhaseStatusFailed     CodeBuildPhaseStatus = "FAILED"
    # 	^
    # events/codebuild.go:31:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
    # 	CodeBuildPhaseTypeSubmitted       CodeBuildPhaseType = "SUBMITTED"
    # 	^
```

In addition, it fixes that `CodeBuildEventDetail.CurrentPhase` and `CodeBuildEventDetail. CompletedPhase` have incorrect type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
