### PR TITLE
reuse runtimeAPIClient.buffer

### DIFF
--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -90,15 +90,15 @@ func (c *runtimeAPIClient) next() (*invoke, error) {
 		return nil, fmt.Errorf("failed to GET %s: got unexpected status code: %d", url, resp.StatusCode)
 	}
 
-	body := bytes.NewBuffer(nil)
-	_, err = io.Copy(body, resp.Body)
+	c.buffer.Reset()
+	_, err = c.buffer.ReadFrom(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the invoke payload: %v", err)
 	}
 
 	return &invoke{
 		id:      resp.Header.Get(headerAWSRequestID),
-		payload: body.Bytes(),
+		payload: c.buffer.Bytes(),
 		headers: resp.Header,
 		client:  c,
 	}, nil


### PR DESCRIPTION
*Issue #, if available:*

`runtimeAPIClient.buffer` is defined on here https://github.com/aws/aws-lambda-go/blob/55dc88be4cdfaaf4bb4d9f65debd8d4310e0a83c/lambda/runtime_api_client.go#L32
but it is never used.

*Description of changes:*

`runtimeAPIClient.next()` is never called concurrently, so we can reuse `runtimeAPIClient.buffer`.
It avoids extra re-allocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
