### PR TITLE
rename safeMarshal to mustMarshal

### DIFF
--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -99,10 +99,13 @@ func convertInvokeRequest(invoke *invoke) (*messages.InvokeRequest, error) {
 	return res, nil
 }
 
+// mustMarshal is like json.Marshal but panics if the v cannot be marshaled.
+// use this if you know the v doesn't contain values that json.Marshal can't marshal,
+// such as Channel, complex, and function values.
 func mustMarshal(v interface{}) []byte {
 	payload, err := json.Marshal(v)
 	if err != nil {
-		panic(err)
+		panic("lambda: " + err.Error())
 	}
 	return payload
 }

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -47,7 +47,7 @@ func handleInvoke(invoke *invoke, function *Function) error {
 	}
 
 	if functionResponse.Error != nil {
-		payload := safeMarshal(functionResponse.Error)
+		payload := mustMarshal(functionResponse.Error)
 		if err := invoke.failure(payload, contentTypeJSON); err != nil {
 			return fmt.Errorf("unexpected error occured when sending the function error to the API: %v", err)
 		}
@@ -99,18 +99,10 @@ func convertInvokeRequest(invoke *invoke) (*messages.InvokeRequest, error) {
 	return res, nil
 }
 
-func safeMarshal(v interface{}) []byte {
+func mustMarshal(v interface{}) []byte {
 	payload, err := json.Marshal(v)
 	if err != nil {
-		v := &messages.InvokeResponse_Error{
-			Type:    "Runtime.SerializationError",
-			Message: err.Error(),
-		}
-		payload, err := json.Marshal(v)
-		if err != nil {
-			panic(err) // never reach
-		}
-		return payload
+		panic(err)
 	}
 	return payload
 }

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	serializationErrorFormat = `{"errorType": "Runtime.SerializationError", "errorMessage": "%s"}`
-	msPerS                   = int64(time.Second / time.Millisecond)
-	nsPerMS                  = int64(time.Millisecond / time.Nanosecond)
+	msPerS  = int64(time.Second / time.Millisecond)
+	nsPerMS = int64(time.Millisecond / time.Nanosecond)
 )
 
 // startRuntimeAPILoop will return an error if handling a particular invoke resulted in a non-recoverable error
@@ -103,7 +102,15 @@ func convertInvokeRequest(invoke *invoke) (*messages.InvokeRequest, error) {
 func safeMarshal(v interface{}) []byte {
 	payload, err := json.Marshal(v)
 	if err != nil {
-		return []byte(fmt.Sprintf(serializationErrorFormat, err.Error()))
+		v := &messages.InvokeResponse_Error{
+			Type:    "Runtime.SerializationError",
+			Message: err.Error(),
+		}
+		payload, err := json.Marshal(v)
+		if err != nil {
+			panic(err) // never reach
+		}
+		return payload
 	}
 	return payload
 }


### PR DESCRIPTION
*Issue #, if available:*

the `safeMarshal` function might return invalid JSON if `err.Error()` contains special characters of JSON.

https://github.com/aws/aws-lambda-go/blob/55dc88be4cdfaaf4bb4d9f65debd8d4310e0a83c/lambda/invoke_loop.go#L103-L109

*Description of changes:*

use `json.Marshal` instead of `fmt.Sprintf`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
