### PR TITLE
Remove URLDecodedKey from S3Object

### DIFF
--- a/events/s3.go
+++ b/events/s3.go
@@ -3,6 +3,8 @@
 package events
 
 import (
+	"encoding/json"
+	"net/url"
 	"time"
 )
 
@@ -52,6 +54,20 @@ type S3Object struct {
 	VersionID     string `json:"versionId"`
 	ETag          string `json:"eTag"`
 	Sequencer     string `json:"sequencer"`
+}
+
+func (o *S3Object) UnmarshalJSON(data []byte) error {
+	type rawS3Object S3Object
+	if err := json.Unmarshal(data, (*rawS3Object)(o)); err != nil {
+		return err
+	}
+	key, err := url.QueryUnescape(o.Key)
+	if err != nil {
+		return err
+	}
+	o.URLDecodedKey = key
+
+	return nil
 }
 
 type S3TestEvent struct {

--- a/events/s3_test.go
+++ b/events/s3_test.go
@@ -26,8 +26,11 @@ func TestS3EventMarshaling(t *testing.T) {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
-	// 4. check result
-	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+	// 4. read expected output JSON from file
+	exepectedOutputJSON := test.ReadJSONFromFile(t, "./testdata/s3-event-with-decoded.json")
+
+	// 5. check result
+	assert.JSONEq(t, string(exepectedOutputJSON), string(outputJSON))
 }
 
 func TestS3TestEventMarshaling(t *testing.T) {

--- a/events/testdata/s3-event-with-decoded.json
+++ b/events/testdata/s3-event-with-decoded.json
@@ -28,6 +28,7 @@
         },
         "object": {
           "key": "Happy%20Face.jpg",
+          "urlDecodedKey": "Happy Face.jpg",
           "size": 1024,
           "versionId": "version",
           "eTag": "d41d8cd98f00b204e9800998ecf8427e",


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/aws-lambda-go/issues/82

*Description of changes:* Populates the `URLDecodedKey` property from the `S3Object` struct as it is currently empty and is never populated by S3 itself https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html

The population implements the convenience method as the lambda Java SDK https://github.com/aws/aws-sdk-java/blob/6a4c873c71320ef0175ca1c13188e9c850a85e51/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java#L176-L183

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
