### PR TITLE
add userNotFound parameter for cognito define auth challenge

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -183,6 +183,7 @@ type CognitoEventUserPoolsDefineAuthChallengeRequest struct {
 	UserAttributes map[string]string                       `json:"userAttributes"`
 	Session        []*CognitoEventUserPoolsChallengeResult `json:"session"`
 	ClientMetadata map[string]string                       `json:"clientMetadata"`
+	UserNotFound   bool                                    `json:"userNotFound"`
 }
 
 // CognitoEventUserPoolsDefineAuthChallengeResponse defines auth challenge response parameters

--- a/events/testdata/cognito-event-userpools-define-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-define-auth-challenge.json
@@ -25,7 +25,8 @@
     ],
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
-    }
+    },
+    "userNotFound": false
   },
   "response": {
     "challengeName": "challengeName",


### PR DESCRIPTION
*Issue #277*

*Description of changes:*
add **UserNotFound** to **CognitoEventUserPoolsDefineAuthChallengeRequest**
https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
