### PR TITLE
Add Amazon MQ event structure

### DIFF
--- a/events/activemq.go
+++ b/events/activemq.go
@@ -3,28 +3,28 @@
 package events
 
 type ActiveMQEvent struct {
-	EventSource    string              `json:"eventSource"`
-	EventSourceArn string              `json:"eventSourceArn"`
-	Messages       []ActiveMQMessage   `json:"messages"`
+	EventSource    string            `json:"eventSource"`
+	EventSourceArn string            `json:"eventSourceArn"`
+	Messages       []ActiveMQMessage `json:"messages"`
 }
 
 type ActiveMQMessage struct {
-	MessageID       string          `json:"messageID"`
-	MessageType     string          `json:"messageType"`
-	Timestamp       int64           `json:"timestamp"`
-	DeliveryMode    int             `json:"deliveryMode"`
-	CorrelationID   string          `json:"correlationID"`
-	ReplyTo         string          `json:"replyTo"`
-	Destination     Destination     `json:"destination"`
-	Redelivered     bool            `json:"redelivered"`
-	Type            string          `json:"type"`
-	Expiration      int64           `json:"expiration"`
-	Priority        int             `json:"priority"`
-	Data            string          `json:"data"`
-	BrokerInTime    int64           `json:"brokerInTime"`
-	BrokerOutTime   int64           `json:"brokerOutTime"`
+	MessageID     string      `json:"messageID"`
+	MessageType   string      `json:"messageType"`
+	Timestamp     int64       `json:"timestamp"`
+	DeliveryMode  int         `json:"deliveryMode"`
+	CorrelationID string      `json:"correlationID"`
+	ReplyTo       string      `json:"replyTo"`
+	Destination   Destination `json:"destination"`
+	Redelivered   bool        `json:"redelivered"`
+	Type          string      `json:"type"`
+	Expiration    int64       `json:"expiration"`
+	Priority      int         `json:"priority"`
+	Data          string      `json:"data"`
+	BrokerInTime  int64       `json:"brokerInTime"`
+	BrokerOutTime int64       `json:"brokerOutTime"`
 }
 
 type Destination struct {
-	PhysicalName     string    `json:"physicalName"`
+	PhysicalName string `json:"physicalName"`
 }

--- a/events/activemq.go
+++ b/events/activemq.go
@@ -4,27 +4,27 @@ package events
 
 type ActiveMQEvent struct {
 	EventSource    string            `json:"eventSource"`
-	EventSourceArn string            `json:"eventSourceArn"`
+	EventSourceARN string            `json:"eventSourceArn"`
 	Messages       []ActiveMQMessage `json:"messages"`
 }
 
 type ActiveMQMessage struct {
-	MessageID     string      `json:"messageID"`
-	MessageType   string      `json:"messageType"`
-	Timestamp     int64       `json:"timestamp"`
-	DeliveryMode  int         `json:"deliveryMode"`
-	CorrelationID string      `json:"correlationID"`
-	ReplyTo       string      `json:"replyTo"`
-	Destination   Destination `json:"destination"`
-	Redelivered   bool        `json:"redelivered"`
-	Type          string      `json:"type"`
-	Expiration    int64       `json:"expiration"`
-	Priority      int         `json:"priority"`
-	Data          string      `json:"data"`
-	BrokerInTime  int64       `json:"brokerInTime"`
-	BrokerOutTime int64       `json:"brokerOutTime"`
+	MessageID     string              `json:"messageID"`
+	MessageType   string              `json:"messageType"`
+	Timestamp     int64               `json:"timestamp"`
+	DeliveryMode  int                 `json:"deliveryMode"`
+	CorrelationID string              `json:"correlationID"`
+	ReplyTo       string              `json:"replyTo"`
+	Destination   ActiveMQDestination `json:"destination"`
+	Redelivered   bool                `json:"redelivered"`
+	Type          string              `json:"type"`
+	Expiration    int64               `json:"expiration"`
+	Priority      int                 `json:"priority"`
+	Data          string              `json:"data"`
+	BrokerInTime  int64               `json:"brokerInTime"`
+	BrokerOutTime int64               `json:"brokerOutTime"`
 }
 
-type Destination struct {
+type ActiveMQDestination struct {
 	PhysicalName string `json:"physicalName"`
 }

--- a/events/activemq.go
+++ b/events/activemq.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package events
+
+type ActiveMQEvent struct {
+	EventSource    string              `json:"eventSource"`
+	EventSourceArn string              `json:"eventSourceArn"`
+	Messages       []ActiveMQMessage   `json:"messages"`
+}
+
+type ActiveMQMessage struct {
+	MessageID       string          `json:"messageID"`
+	MessageType     string          `json:"messageType"`
+	Timestamp       int64           `json:"timestamp"`
+	DeliveryMode    int             `json:"deliveryMode"`
+	CorrelationID   string          `json:"correlationID"`
+	ReplyTo         string          `json:"replyTo"`
+	Destination     Destination     `json:"destination"`
+	Redelivered     bool            `json:"redelivered"`
+	Type            string          `json:"type"`
+	Expiration      int64           `json:"expiration"`
+	Priority        int             `json:"priority"`
+	Data            string          `json:"data"`
+	BrokerInTime    int64           `json:"brokerInTime"`
+	BrokerOutTime   int64           `json:"brokerOutTime"`
+}
+
+type Destination struct {
+	PhysicalName     string    `json:"physicalName"`
+}

--- a/events/activemq_test.go
+++ b/events/activemq_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveMQEventMarshaling(t *testing.T) {
+	// 1. read JSON from file
+	inputJson := test.ReadJSONFromFile(t, "./testdata/activemq-event.json")
+
+	// 2. de-serialize into Go object
+	var inputEvent ActiveMQEvent
+	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// 3. Verify values populated into Go Object, at least one validation per data type
+	assert.Equal(t, "aws:mq", inputEvent.EventSource)
+	assert.Equal(t, "arn:aws:mq:us-west-2:533019413397:broker:shask-test:b-0f5b7522-2b41-4f85-a615-735a4e6d96b5", inputEvent.EventSourceArn)
+	assert.Equal(t, 1, len(inputEvent.Messages))
+
+	var message = inputEvent.Messages[0]
+	assert.Equal(t, "jms/text-message", message.MessageType)
+	assert.Equal(t, int64(1599863938941), message.Timestamp)
+	assert.Equal(t, 1, message.DeliveryMode)
+	assert.Equal(t, "testQueue", message.Destination.PhysicalName)
+	assert.Equal(t, false, message.Redelivered)
+
+	// 4. serialize to JSON
+	outputJson, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	// 5. check result
+	assert.JSONEq(t, string(inputJson), string(outputJson))
+}
+
+func TestActiveMQMarshalingMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, ActiveMQEvent{})
+}

--- a/events/activemq_test.go
+++ b/events/activemq_test.go
@@ -21,7 +21,7 @@ func TestActiveMQEventMarshaling(t *testing.T) {
 
 	// 3. Verify values populated into Go Object, at least one validation per data type
 	assert.Equal(t, "aws:mq", inputEvent.EventSource)
-	assert.Equal(t, "arn:aws:mq:us-west-2:533019413397:broker:shask-test:b-0f5b7522-2b41-4f85-a615-735a4e6d96b5", inputEvent.EventSourceArn)
+	assert.Equal(t, "arn:aws:mq:us-west-2:533019413397:broker:shask-test:b-0f5b7522-2b41-4f85-a615-735a4e6d96b5", inputEvent.EventSourceARN)
 	assert.Equal(t, 1, len(inputEvent.Messages))
 
 	var message = inputEvent.Messages[0]

--- a/events/testdata/activemq-event.json
+++ b/events/testdata/activemq-event.json
@@ -1,0 +1,24 @@
+{
+    "eventSource": "aws:mq",
+    "eventSourceArn": "arn:aws:mq:us-west-2:533019413397:broker:shask-test:b-0f5b7522-2b41-4f85-a615-735a4e6d96b5",
+    "messages": [
+        {
+            "messageID": "ID:b-0f5b7522-2b41-4f85-a615-735a4e6d96b5-2.mq.us-west-2.amazonaws.com-34859-1598944546501-4:12:1:1:3",
+            "messageType": "jms/text-message",
+            "timestamp": 1599863938941,
+            "deliveryMode": 1,
+            "correlationID": "",
+            "replyTo": "null",
+            "destination": {
+                "physicalName": "testQueue"
+            },
+            "redelivered": false,
+            "type": "",
+            "expiration": 0,
+            "priority": 0,
+            "data": "RW50ZXIgc29tZSB0ZXh0IGhlcmUgZm9yIHRoZSBtZXNzYWdlIGJvZHkuLi4=",
+            "brokerInTime": 1599863938943,
+            "brokerOutTime": 1599863938944
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds event structure for Amazon Active MQ.

*Testing
Unit tested.
Created a go lambda function with ActiveMQEvent as input event and validated event deserialization by creating an event source mapping for an ActiveMQ queue on Amazon ActiveMQ broker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
