### PR TITLE
Add `omitempty` to `HTTPMethod` in `APIGatewayProxyRequest`

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -6,7 +6,7 @@ package events
 type APIGatewayProxyRequest struct {
 	Resource                        string                        `json:"resource"` // The resource path defined in API Gateway
 	Path                            string                        `json:"path"`     // The url path for the caller
-	HTTPMethod                      string                        `json:"httpMethod"`
+	HTTPMethod                      string                        `json:"httpMethod,omitempty"`
 	Headers                         map[string]string             `json:"headers"`
 	MultiValueHeaders               map[string][]string           `json:"multiValueHeaders"`
 	QueryStringParameters           map[string]string             `json:"queryStringParameters"`


### PR DESCRIPTION
This can be empty for websocket events, see https://github.com/LegNeato/aws-lambda-events/issues/33

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
