### PR TITLE
ValidationData field added to CognitoEventUserPoolsMigrateUserRequest

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -144,6 +144,7 @@ type CognitoEventUserPoolsPostAuthenticationResponse struct {
 // CognitoEventUserPoolsMigrateUserRequest contains the request portion of a MigrateUser event
 type CognitoEventUserPoolsMigrateUserRequest struct {
 	Password       string            `json:"password"`
+	ValidationData map[string]string `json:"validationData"`
 	ClientMetadata map[string]string `json:"clientMetadata"`
 }
 

--- a/events/testdata/cognito-event-userpools-migrateuser.json
+++ b/events/testdata/cognito-event-userpools-migrateuser.json
@@ -10,9 +10,12 @@
     },
     "request": {
         "password": "<password>",
+        "validationData": {
+            "exampleMetadataKey": "example metadata value"
+        },
         "clientMetadata": {
             "exampleMetadataKey": "example metadata value"
-          }
+        }
     },
     "response": {
         "userAttributes": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
According to AWS docs, values passed in ClientMetaData to AdminInitiateUs will be passed to lambda as validationData. Though this field doesn't exist in the CognitoEventUserPoolsMigrateUserRequest

[Request sample and Explanation on AWS docs](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html#json)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
