### PR TITLE
Use http.Header for MultiValueHeaders

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -24,11 +24,11 @@ type APIGatewayProxyRequest struct {
 
 // APIGatewayProxyResponse configures the response to be returned by API Gateway for the request
 type APIGatewayProxyResponse struct {
-	StatusCode        int                 `json:"statusCode"`
-	Headers           map[string]string   `json:"headers"`
-	MultiValueHeaders http.Header         `json:"multiValueHeaders"`
-	Body              string              `json:"body"`
-	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
+	StatusCode        int               `json:"statusCode"`
+	Headers           map[string]string `json:"headers"`
+	MultiValueHeaders http.Header       `json:"multiValueHeaders"`
+	Body              string            `json:"body"`
+	IsBase64Encoded   bool              `json:"isBase64Encoded,omitempty"`
 }
 
 // APIGatewayProxyRequestContext contains the information to identify the AWS account and resources invoking the
@@ -124,12 +124,12 @@ type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 
 // APIGatewayV2HTTPResponse configures the response to be returned by API Gateway V2 for the request
 type APIGatewayV2HTTPResponse struct {
-	StatusCode        int                 `json:"statusCode"`
-	Headers           map[string]string   `json:"headers"`
-	MultiValueHeaders http.Header         `json:"multiValueHeaders"`
-	Body              string              `json:"body"`
-	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
-	Cookies           []string            `json:"cookies"`
+	StatusCode        int               `json:"statusCode"`
+	Headers           map[string]string `json:"headers"`
+	MultiValueHeaders http.Header       `json:"multiValueHeaders"`
+	Body              string            `json:"body"`
+	IsBase64Encoded   bool              `json:"isBase64Encoded,omitempty"`
+	Cookies           []string          `json:"cookies"`
 }
 
 // APIGatewayRequestIdentity contains identity information for the request caller.

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -2,13 +2,17 @@
 
 package events
 
+import (
+	"net/http"
+)
+
 // APIGatewayProxyRequest contains data coming from the API Gateway proxy
 type APIGatewayProxyRequest struct {
 	Resource                        string                        `json:"resource"` // The resource path defined in API Gateway
 	Path                            string                        `json:"path"`     // The url path for the caller
 	HTTPMethod                      string                        `json:"httpMethod"`
 	Headers                         map[string]string             `json:"headers"`
-	MultiValueHeaders               map[string][]string           `json:"multiValueHeaders"`
+	MultiValueHeaders               http.Header                   `json:"multiValueHeaders"`
 	QueryStringParameters           map[string]string             `json:"queryStringParameters"`
 	MultiValueQueryStringParameters map[string][]string           `json:"multiValueQueryStringParameters"`
 	PathParameters                  map[string]string             `json:"pathParameters"`
@@ -22,7 +26,7 @@ type APIGatewayProxyRequest struct {
 type APIGatewayProxyResponse struct {
 	StatusCode        int                 `json:"statusCode"`
 	Headers           map[string]string   `json:"headers"`
-	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	MultiValueHeaders http.Header         `json:"multiValueHeaders"`
 	Body              string              `json:"body"`
 	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 }
@@ -122,7 +126,7 @@ type APIGatewayV2HTTPRequestContextHTTPDescription struct {
 type APIGatewayV2HTTPResponse struct {
 	StatusCode        int                 `json:"statusCode"`
 	Headers           map[string]string   `json:"headers"`
-	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	MultiValueHeaders http.Header         `json:"multiValueHeaders"`
 	Body              string              `json:"body"`
 	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 	Cookies           []string            `json:"cookies"`
@@ -151,7 +155,7 @@ type APIGatewayWebsocketProxyRequest struct {
 	Path                            string                                 `json:"path"`     // The url path for the caller
 	HTTPMethod                      string                                 `json:"httpMethod"`
 	Headers                         map[string]string                      `json:"headers"`
-	MultiValueHeaders               map[string][]string                    `json:"multiValueHeaders"`
+	MultiValueHeaders               http.Header                            `json:"multiValueHeaders"`
 	QueryStringParameters           map[string]string                      `json:"queryStringParameters"`
 	MultiValueQueryStringParameters map[string][]string                    `json:"multiValueQueryStringParameters"`
 	PathParameters                  map[string]string                      `json:"pathParameters"`
@@ -232,7 +236,7 @@ type APIGatewayCustomAuthorizerRequestTypeRequest struct {
 	Path                            string                                              `json:"path"`
 	HTTPMethod                      string                                              `json:"httpMethod"`
 	Headers                         map[string]string                                   `json:"headers"`
-	MultiValueHeaders               map[string][]string                                 `json:"multiValueHeaders"`
+	MultiValueHeaders               http.Header                                         `json:"multiValueHeaders"`
 	QueryStringParameters           map[string]string                                   `json:"queryStringParameters"`
 	MultiValueQueryStringParameters map[string][]string                                 `json:"multiValueQueryStringParameters"`
 	PathParameters                  map[string]string                                   `json:"pathParameters"`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use `http.Header` type for `MultiValueHeaders` field in the following types:
* `APIGatewayProxyRequest`
* `APIGatewayProxyResponse`
* `APIGatewayV2HTTPResponse`
* `APIGatewayWebsocketProxyRequest`
* `APIGatewayCustomAuthorizerRequestTypeRequest`

The change is backwards compatible and makes it easier to work with headers in requests and responses. By allowing developers to do `response.MultiValueHeaders.Set("Content-Type", "plain/text")` or better yet `response.MultiValueHeaders.Add("Set-Cookie", "ping=pong")`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
