### PR TITLE
Omit HTTPMethod in APIGatewayWebsocketProxyRequest

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -149,7 +149,7 @@ type APIGatewayRequestIdentity struct {
 type APIGatewayWebsocketProxyRequest struct {
 	Resource                        string                                 `json:"resource"` // The resource path defined in API Gateway
 	Path                            string                                 `json:"path"`     // The url path for the caller
-	HTTPMethod                      string                                 `json:"httpMethod"`
+	HTTPMethod                      string                                 `json:"httpMethod,omitempty"`
 	Headers                         map[string]string                      `json:"headers"`
 	MultiValueHeaders               map[string][]string                    `json:"multiValueHeaders"`
 	QueryStringParameters           map[string]string                      `json:"queryStringParameters"`


### PR DESCRIPTION
These requests don't always include the HTTP Method, since the websocket protocol doesn't enforce it.

This supersedes https://github.com/aws/aws-lambda-go/pull/350. That PR can be closed.

Signed-off-by: David Calavera <david.calavera@gmail.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
