### PR TITLE
Update Lex Event to include the confidence score and alternative intents 

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -20,10 +20,19 @@ type LexBot struct {
 }
 
 type LexCurrentIntent struct {
-	Name               string                `json:"name,omitempty"`
-	Slots              Slots                 `json:"slots,omitempty"`
-	SlotDetails        map[string]SlotDetail `json:"slotDetails,omitempty"`
-	ConfirmationStatus string                `json:"confirmationStatus,omitempty"`
+	Name                     string                `json:"name,omitempty"`
+	nluIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
+	Slots							       Slots                 `json:"slots,omitempty"`
+	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
+	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
+}
+
+type LexAlternativeIntent struct {
+	Name                     string                `json:"name,omitempty"`
+	nluIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
+	Slots							       Slots                 `json:"slots,omitempty"`
+	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
+	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
 }
 
 type SlotDetail struct {

--- a/events/lex.go
+++ b/events/lex.go
@@ -22,7 +22,7 @@ type LexBot struct {
 type LexCurrentIntent struct {
 	Name                     string                `json:"name,omitempty"`
 	nluIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
-	Slots							       Slots                 `json:"slots,omitempty"`
+	Slots                    Slots                 `json:"slots,omitempty"`
 	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
 	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
 }
@@ -30,7 +30,7 @@ type LexCurrentIntent struct {
 type LexAlternativeIntent struct {
 	Name                     string                `json:"name,omitempty"`
 	nluIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
-	Slots							       Slots                 `json:"slots,omitempty"`
+	Slots                    Slots                 `json:"slots,omitempty"`
 	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
 	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
 }


### PR DESCRIPTION
This change includes the **nluIntentConfidenceScore** and **alternativeIntents** fields in the LexEvent struct. The latest version for the input event format has been referenced from - https://docs.aws.amazon.com/lex/latest/dg/lambda-input-response-format.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.