### PR TITLE
Update Lex event to include confidence score and alternative intents

### DIFF
--- a/events/lex.go
+++ b/events/lex.go
@@ -1,17 +1,17 @@
 package events
 
 type LexEvent struct {
-	MessageVersion    string                `json:"messageVersion,omitempty"`
-	InvocationSource  string                `json:"invocationSource,omitempty"`
-	UserID            string                `json:"userId,omitempty"`
-	InputTranscript   string                `json:"inputTranscript,omitempty"`
-	SessionAttributes SessionAttributes     `json:"sessionAttributes,omitempty"`
-	RequestAttributes map[string]string     `json:"requestAttributes,omitempty"`
-	Bot               *LexBot               `json:"bot,omitempty"`
-	OutputDialogMode  string                `json:"outputDialogMode,omitempty"`
-	CurrentIntent     *LexCurrentIntent     `json:"currentIntent,omitempty"`
-	AlternativeIntent *LexAlternativeIntent `json:"alternativeIntent,omitempty"`
-	DialogAction      *LexDialogAction      `json:"dialogAction,omitempty"`
+	MessageVersion     string                  `json:"messageVersion,omitempty"`
+	InvocationSource   string                  `json:"invocationSource,omitempty"`
+	UserID             string                  `json:"userId,omitempty"`
+	InputTranscript    string                  `json:"inputTranscript,omitempty"`
+	SessionAttributes  SessionAttributes       `json:"sessionAttributes,omitempty"`
+	RequestAttributes  map[string]string       `json:"requestAttributes,omitempty"`
+	Bot                *LexBot                 `json:"bot,omitempty"`
+	OutputDialogMode   string                  `json:"outputDialogMode,omitempty"`
+	CurrentIntent      *LexCurrentIntent       `json:"currentIntent,omitempty"`
+	AlternativeIntents []LexAlternativeIntents `json:"alternativeIntents,omitempty"`
+	DialogAction       *LexDialogAction        `json:"dialogAction,omitempty"`
 }
 
 type LexBot struct {
@@ -28,7 +28,7 @@ type LexCurrentIntent struct {
 	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
 }
 
-type LexAlternativeIntent struct {
+type LexAlternativeIntents struct {
 	Name                     string                `json:"name,omitempty"`
 	NLUIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
 	Slots                    Slots                 `json:"slots,omitempty"`

--- a/events/lex.go
+++ b/events/lex.go
@@ -1,16 +1,17 @@
 package events
 
 type LexEvent struct {
-	MessageVersion    string            `json:"messageVersion,omitempty"`
-	InvocationSource  string            `json:"invocationSource,omitempty"`
-	UserID            string            `json:"userId,omitempty"`
-	InputTranscript   string            `json:"inputTranscript,omitempty"`
-	SessionAttributes SessionAttributes `json:"sessionAttributes,omitempty"`
-	RequestAttributes map[string]string `json:"requestAttributes,omitempty"`
-	Bot               *LexBot           `json:"bot,omitempty"`
-	OutputDialogMode  string            `json:"outputDialogMode,omitempty"`
-	CurrentIntent     *LexCurrentIntent `json:"currentIntent,omitempty"`
-	DialogAction      *LexDialogAction  `json:"dialogAction,omitempty"`
+	MessageVersion    string                `json:"messageVersion,omitempty"`
+	InvocationSource  string                `json:"invocationSource,omitempty"`
+	UserID            string                `json:"userId,omitempty"`
+	InputTranscript   string                `json:"inputTranscript,omitempty"`
+	SessionAttributes SessionAttributes     `json:"sessionAttributes,omitempty"`
+	RequestAttributes map[string]string     `json:"requestAttributes,omitempty"`
+	Bot               *LexBot               `json:"bot,omitempty"`
+	OutputDialogMode  string                `json:"outputDialogMode,omitempty"`
+	CurrentIntent     *LexCurrentIntent     `json:"currentIntent,omitempty"`
+	AlternativeIntent *LexAlternativeIntent `json:"alternativeIntent,omitempty"`
+	DialogAction      *LexDialogAction      `json:"dialogAction,omitempty"`
 }
 
 type LexBot struct {
@@ -20,10 +21,19 @@ type LexBot struct {
 }
 
 type LexCurrentIntent struct {
-	Name               string                `json:"name,omitempty"`
-	Slots              Slots                 `json:"slots,omitempty"`
-	SlotDetails        map[string]SlotDetail `json:"slotDetails,omitempty"`
-	ConfirmationStatus string                `json:"confirmationStatus,omitempty"`
+	Name                     string                `json:"name,omitempty"`
+	NLUIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
+	Slots                    Slots                 `json:"slots,omitempty"`
+	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
+	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
+}
+
+type LexAlternativeIntent struct {
+	Name                     string                `json:"name,omitempty"`
+	NLUIntentConfidenceScore float64               `json:"nluIntentConfidenceScore,omitempty"`
+	Slots                    Slots                 `json:"slots,omitempty"`
+	SlotDetails              map[string]SlotDetail `json:"slotDetails,omitempty"`
+	ConfirmationStatus       string                `json:"confirmationStatus,omitempty"`
 }
 
 type SlotDetail struct {


### PR DESCRIPTION
**Description of changes:**
The  Lex event has been updated to include the NLU confidence score and alternative intents fields. This change has been done as per the sample input event format provided [here](https://docs.aws.amazon.com/lex/latest/dg/lambda-input-response-format.html). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.