### PR TITLE
Update tests.yaml to use build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
-        if: matrix.go == "1.16"
+        if: matrix.go == '1.16'
         with:
           file: ./coverage.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        if: matrix.go == "1.16"
         with:
           file: ./coverage.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,25 @@
 name: tests
-on: 
+on:
   push:
   pull_request:
 
 jobs:
-
   test:
-    name: run tests with go 1.16 and code coverage  
+    name: run tests with code coverage
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - "1.16"
+          - "1.15"
+          - "1.14"
+          - "1.13"
+
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
@@ -20,56 +27,8 @@ jobs:
 
       - name: go test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-      
-      - name: Upload coverage to Codecov  
+
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-         file: ./coverage.txt
-
-  test-v115:
-    name: run tests with go 1.15 
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.15
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: go test
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-  test-v114:
-    name: run tests with go 1.14
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.14
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: go test
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-  test-v113:
-    name: run tests with go 1.13
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: go test
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+          file: ./coverage.txt


### PR DESCRIPTION
GitHub Actions supports using a build matrix, it can run tests in multiple versions.

I suggest this implementation because using this method is easier to maintain.