### PR TITLE
improvement of validating arguments

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -55,8 +55,19 @@ func handlerTakesContext(handler reflect.Type) (bool, error) {
 			return false, fmt.Errorf("handler takes an interface, but context.Context does not implement it: %s", argumentType.Name())
 		}
 		if argumentType.NumMethod() == 0 {
-			// the first argument might be TIn or context.Context.
-			// we choose TIn for backward compatibility.
+			// In this case, the signature of the handler is func (v interface{}).
+			// We have two choices to call the handler.
+			//
+			//     ctx := context.TODO()
+			//     handler(ctx)
+			//
+			// or
+			//
+			//     v, _ := json.Unmarshal(data)
+			//     handler(v)
+			//
+			// Calling the handler succeeds in either case, but we need to choose one of them.
+			// We choose the second for backward compatibility.
 			return false, nil
 		}
 		return true, nil

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -52,7 +52,7 @@ func handlerTakesContext(handler reflect.Type) (bool, error) {
 			return false, nil
 		}
 		if !contextType.Implements(argumentType) {
-			return false, fmt.Errorf("handler takes an interface, but context.Context does not implement it: %s", argumentType.Name())
+			return false, fmt.Errorf("handler takes an interface, but context.Context does not implement it: %q", argumentType.Name())
 		}
 		if argumentType.NumMethod() == 0 {
 			// In this case, the signature of the handler is func (v interface{}).

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -5,7 +5,6 @@ package lambda
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -52,7 +51,7 @@ func validateArguments(handler reflect.Type) (bool, error) {
 			return false, nil
 		}
 		if !contextType.Implements(argumentType) {
-			return false, errors.New("the first argument is an interface, but it is not a Context")
+			return false, fmt.Errorf("handler takes an interface, but context.Context does not implement it: %s", argumentType.Name())
 		}
 		if argumentType.NumMethod() == 0 {
 			// the first argument might be TIn or context.Context.

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -40,7 +40,8 @@ func errorHandler(e error) lambdaHandler {
 	}
 }
 
-func validateArguments(handler reflect.Type) (bool, error) {
+// handlerTakesContext returns whether the handler takes a context.Context as its first argument.
+func handlerTakesContext(handler reflect.Type) (bool, error) {
 	switch handler.NumIn() {
 	case 0:
 		return false, nil
@@ -104,7 +105,7 @@ func NewHandler(handlerFunc interface{}) Handler {
 		return errorHandler(fmt.Errorf("handler kind %s is not %s", handlerType.Kind(), reflect.Func))
 	}
 
-	takesContext, err := validateArguments(handlerType)
+	takesContext, err := handlerTakesContext(handlerType)
 	if err != nil {
 		return errorHandler(err)
 	}

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -15,6 +15,15 @@ import (
 
 func TestInvalidHandlers(t *testing.T) {
 
+	type valuer interface {
+		Value(key interface{}) interface{}
+	}
+
+	type customContext interface {
+		context.Context
+		MyCustomMethod()
+	}
+
 	testCases := []struct {
 		name     string
 		handler  interface{}
@@ -71,12 +80,46 @@ func TestInvalidHandlers(t *testing.T) {
 			handler: func() {
 			},
 		},
+		{
+			name:     "the handler takes the empty interface",
+			expected: nil,
+			handler: func(v interface{}) error {
+				if _, ok := v.(context.Context); ok {
+					return errors.New("v should not be a Context")
+				}
+				return nil
+			},
+		},
+		{
+			name:     "the handler takes a subset of context.Context",
+			expected: nil,
+			handler: func(ctx valuer) {
+			},
+		},
+		{
+			name:     "the handler takes a superset of context.Context",
+			expected: errors.New("the first argument is an interface, but it is not a Context"),
+			handler: func(ctx customContext) {
+			},
+		},
+		{
+			name:     "the handler takes two arguments and first argument is a subset of context.Context",
+			expected: nil,
+			handler: func(ctx valuer, v interface{}) {
+			},
+		},
+		{
+			name:     "the handler takes two arguments and first argument is a superset of context.Context",
+			expected: errors.New("handler takes two arguments, but the first is not Context. got interface"),
+			handler: func(ctx customContext, v interface{}) {
+			},
+		},
 	}
 	for i, testCase := range testCases {
 		testCase := testCase
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
 			lambdaHandler := NewHandler(testCase.handler)
-			_, err := lambdaHandler.Invoke(context.TODO(), make([]byte, 0))
+			_, err := lambdaHandler.Invoke(context.TODO(), []byte("{}"))
 			assert.Equal(t, testCase.expected, err)
 		})
 	}

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -98,7 +98,7 @@ func TestInvalidHandlers(t *testing.T) {
 		},
 		{
 			name:     "the handler takes a superset of context.Context",
-			expected: errors.New("the first argument is an interface, but it is not a Context"),
+			expected: errors.New("handler takes an interface, but context.Context does not implement it: customContext"),
 			handler: func(ctx customContext) {
 			},
 		},

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -98,7 +98,7 @@ func TestInvalidHandlers(t *testing.T) {
 		},
 		{
 			name:     "the handler takes a superset of context.Context",
-			expected: errors.New("handler takes an interface, but context.Context does not implement it: customContext"),
+			expected: errors.New("handler takes an interface, but context.Context does not implement it: \"customContext\""),
 			handler: func(ctx customContext) {
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*

I passed `interface { Value(key interface{}) interface{} }` to the first argument of the handler.

```go
package main

import (
	"github.com/aws/aws-lambda-go/events"
	"github.com/aws/aws-lambda-go/lambda" // v1.13.3
)

type valuer interface {
	Value(key interface{}) interface{}
}

func handler(ctx valuer, v interface{}) (events.APIGatewayProxyResponse, error) {
	return events.APIGatewayProxyResponse{
		Body:       "Hello",
		StatusCode: 200,
	}, nil
}

func main() {
	lambda.Start(handler)
}
```

**Actual Behavior:**
It fails with "handler takes two arguments, but the first is not Context. got interface".
Here is the result of running with SAM CLI.

```
% curl http://localhost:3000/hello
{"message":"Internal server error"}
```

```
% sam local start-api
Mounting HelloWorldFunction at http://127.0.0.1:3000/hello [GET]
You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template
2021-03-07 18:19:00  * Running on http://127.0.0.1:3000/ (Press CTRL+C to quit)
Invoking hello-world (go1.x)
Skip pulling image and use local one: amazon/aws-sam-cli-emulation-image-go1.x:rapid-1.20.0.

Mounting /Users/shogoichinose/tmp/2021-03-07-lambda-context/aws-sam-golang/.aws-sam/build/HelloWorldFunction as /var/task:ro,delegated inside runtime container
START RequestId: 2cdebf6d-a4fa-4e36-bf64-996d10686f29 Version: $LATEST
handler takes two arguments, but the first is not Context. got interface: errorString
null
END RequestId: 2cdebf6d-a4fa-4e36-bf64-996d10686f29
REPORT RequestId: 2cdebf6d-a4fa-4e36-bf64-996d10686f29  Init Duration: 0.27 ms  Duration: 100.46 ms     Billed Duration: 200 ms Memory Size: 128 MB     Max Memory Used: 128 MB
Lambda returned empty body!
Invalid lambda response received: Invalid API Gateway Response Keys: {'errorType', 'errorMessage'} in {'errorMessage': 'handler takes two arguments, but the first is not Context. got interface', 'errorType': 'errorString'}
2021-03-07 18:19:05 127.0.0.1 - - [07/Mar/2021 18:19:05] "GET /hello HTTP/1.1" 502 -
```

**Expected Behavior:**
It should be same result as the first argument is `context.Context`.

```go
package main

import (
	"context"

	"github.com/aws/aws-lambda-go/events"
	"github.com/aws/aws-lambda-go/lambda"
)

func handler(ctx context.Context, v interface{}) (events.APIGatewayProxyResponse, error) {
	return events.APIGatewayProxyResponse{
		Body:       "Hello",
		StatusCode: 200,
	}, nil
}

func main() {
	lambda.Start(handler)
}
```

```
% curl http://localhost:3000/hello
Hello
```

```
% sam local start-api
Mounting HelloWorldFunction at http://127.0.0.1:3000/hello [GET]
You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template
2021-03-07 18:20:01  * Running on http://127.0.0.1:3000/ (Press CTRL+C to quit)
Invoking hello-world (go1.x)
Skip pulling image and use local one: amazon/aws-sam-cli-emulation-image-go1.x:rapid-1.20.0.

Mounting /Users/shogoichinose/tmp/2021-03-07-lambda-context/aws-sam-golang/.aws-sam/build/HelloWorldFunction as /var/task:ro,delegated inside runtime container
END RequestId: 4827cdf0-3fab-4a19-b352-f3f10977d442
REPORT RequestId: 4827cdf0-3fab-4a19-b352-f3f10977d442  Init Duration: 0.17 ms  Duration: 111.62 ms     Billed Duration: 200 ms Memory Size: 128 MB     Max Memory Used: 128 MB
No Content-Type given. Defaulting to 'application/json'.
2021-03-07 18:20:05 127.0.0.1 - - [07/Mar/2021 18:20:05] "GET /hello HTTP/1.1" 200 -
```

**Another example:**

```go
package main

import (
	"context"

	"github.com/aws/aws-lambda-go/events"
	"github.com/aws/aws-lambda-go/lambda"
)

type customContext interface {
	context.Context
	MyCustomMethod()
}

func handler(ctx customContext, v interface{}) (events.APIGatewayProxyResponse, error) {
	return events.APIGatewayProxyResponse{
		Body:       "Hello",
		StatusCode: 200,
	}, nil
}

func main() {
	lambda.Start(handler)
}
```

It panics with "reflect: Call using *context.valueCtx as type main.customContext".
aws/aws-lambda-go should return an error with more friendly message.

```
% curl http://localhost:3000/hello
{"message":"Internal server error"}
```

```
% sam local start-api
Mounting HelloWorldFunction at http://127.0.0.1:3000/hello [GET]
You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template
2021-03-07 18:16:20  * Running on http://127.0.0.1:3000/ (Press CTRL+C to quit)
Invoking hello-world (go1.x)
Skip pulling image and use local one: amazon/aws-sam-cli-emulation-image-go1.x:rapid-1.20.0.

Mounting /Users/shogoichinose/tmp/2021-03-07-lambda-context/aws-sam-golang/.aws-sam/build/HelloWorldFunction as /var/task:ro,delegated inside runtime container
START RequestId: 0ae34f7a-c15b-45ce-a094-0e5d7800324e Version: $LATEST
reflect: Call using *context.valueCtx as type main.customContext: string
[{"path":"github.com/aws/aws-lambda-go@v1.13.3/lambda/function.go","line":35,"label":"(*Function).Invoke.func1"},{"path":"runtime/panic.go","line":965,"label":"gopanic"},{"path":"reflect/value.go","line":406,"label":"Value.call"},{"path":"reflect/value.go","line":337,"label":"Value.Call"},{"path":"github.com/aws/aws-lambda-go@v1.13.3/lambda/handler.go","line":124,"label":"NewHandler.func1"},{"path":"github.com/aws/aws-lambda-go@v1.13.3/lambda/handler.go","line":24,"label":"lambdaHandler.Invoke"},{"path":"github.com/aws/aws-lambda-go@v1.13.3/lambda/function.go","line":67,"label":"(*Function).Invoke"},{"path":"reflect/value.go","line":476,"label":"Value.call"},{"path":"reflect/value.go","line":337,"label":"Value.Call"},{"path":"net/rpc/server.go","line":377,"label":"(*service).call"},{"path":"runtime/asm_amd64.s","line":1371,"label":"goexit"}]
END RequestId: 0ae34f7a-c15b-45ce-a094-0e5d7800324e
REPORT RequestId: 0ae34f7a-c15b-45ce-a094-0e5d7800324e  Init Duration: 0.18 ms  Duration: 81.29 ms      Billed Duration: 100 ms Memory Size: 128 MB     Max Memory Used: 128 MB
Lambda returned empty body!
Invalid lambda response received: Invalid API Gateway Response Keys: {'errorType', 'errorMessage', 'stackTrace'} in {'errorMessage': 'reflect: Call using *context.valueCtx as type main.customContext', 'errorType': 'string', 'stackTrace': [{'path': 'github.com/aws/aws-lambda-go@v1.13.3/lambda/function.go', 'line': 35, 'label': '(*Function).Invoke.func1'}, {'path': 'runtime/panic.go', 'line': 965, 'label': 'gopanic'}, {'path': 'reflect/value.go', 'line': 406, 'label': 'Value.call'}, {'path': 'reflect/value.go', 'line': 337, 'label': 'Value.Call'}, {'path': 'github.com/aws/aws-lambda-go@v1.13.3/lambda/handler.go', 'line': 124, 'label': 'NewHandler.func1'}, {'path': 'github.com/aws/aws-lambda-go@v1.13.3/lambda/handler.go', 'line': 24, 'label': 'lambdaHandler.Invoke'}, {'path': 'github.com/aws/aws-lambda-go@v1.13.3/lambda/function.go', 'line': 67, 'label': '(*Function).Invoke'}, {'path': 'reflect/value.go', 'line': 476, 'label': 'Value.call'}, {'path': 'reflect/value.go', 'line': 337, 'label': 'Value.Call'}, {'path': 'net/rpc/server.go', 'line': 377, 'label': '(*service).call'}, {'path': 'runtime/asm_amd64.s', 'line': 1371, 'label': 'goexit'}]}
2021-03-07 18:16:27 127.0.0.1 - - [07/Mar/2021 18:16:27] "GET /hello HTTP/1.1" 502 -
```

*Description of changes:*

The `validateArguments` validates that the first argument implements `context.Context`.
It is documented in the official document:

> https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html#golang-handler-structs
> The handler may take between 0 and 2 arguments. If there are two arguments, the first argument must implement context.Context.

The `validateArguments` should validate that the first argument **is an interface and a subset of** `context.Context`.

> The handler may take between 0 and 2 arguments. If there are two arguments, the first argument must **be an interface and a subset of** context.Context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
