### PR TITLE
migrate the godoc badge to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![tests][1]][2]
 [![build-lambda-zip][3]][4]
-[![GoDoc][5]][6]
+[![Go Reference][5]][6]
 [![GoCard][7]][8]
 [![codecov][9]][10]
 
@@ -10,8 +10,8 @@
 [2]: https://github.com/aws/aws-lambda-go/actions?query=workflow%3Atests
 [3]: https://github.com/aws/aws-lambda-go/workflows/go%20get%20build-lambda-zip/badge.svg
 [4]: https://github.com/aws/aws-lambda-go/actions?query=workflow%3A%22go+get+build-lambda-zip%22
-[5]: https://godoc.org/github.com/aws/aws-lambda-go?status.svg
-[6]: https://godoc.org/github.com/aws/aws-lambda-go
+[5]: https://pkg.go.dev/badge/github.com/aws/aws-lambda-go.svg
+[6]: https://pkg.go.dev/github.com/aws/aws-lambda-go
 [7]: https://goreportcard.com/badge/github.com/aws/aws-lambda-go
 [8]: https://goreportcard.com/report/github.com/aws/aws-lambda-go
 [9]: https://codecov.io/gh/aws/aws-lambda-go/branch/master/graph/badge.svg

--- a/events/README.md
+++ b/events/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-[![GoDoc](https://godoc.org/github.com/aws/aws-lambda-go/events?status.svg)](https://godoc.org/github.com/aws/aws-lambda-go/events)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aws/aws-lambda-go/events.svg)](https://pkg.go.dev/github.com/aws/aws-lambda-go/events)
 
 This package provides input types for Lambda functions that process AWS events.
 

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,3 +1,3 @@
 # Overview
 
-[![GoDoc](https://godoc.org/github.com/aws/aws-lambda-go/lambda?status.svg)](https://godoc.org/github.com/aws/aws-lambda-go/lambda)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aws/aws-lambda-go/lambda.svg)](https://pkg.go.dev/github.com/aws/aws-lambda-go/lambda)

--- a/lambda/messages/README.md
+++ b/lambda/messages/README.md
@@ -1,3 +1,3 @@
 # Overview
 
-[![GoDoc](https://godoc.org/github.com/aws/aws-lambda-go/lambda/messages?status.svg)](https://godoc.org/github.com/aws/aws-lambda-go/lambda/messages)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aws/aws-lambda-go/lambda/messages.svg)](https://pkg.go.dev/github.com/aws/aws-lambda-go/lambda/messages)

--- a/lambdacontext/README.md
+++ b/lambdacontext/README.md
@@ -1,3 +1,3 @@
 # Overview
 
-[![GoDoc](https://godoc.org/github.com/aws/aws-lambda-go/lambdacontext?status.svg)](https://godoc.org/github.com/aws/aws-lambda-go/lambdacontext)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aws/aws-lambda-go/lambdacontext.svg)](https://pkg.go.dev/github.com/aws/aws-lambda-go/lambdacontext)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

migrate links for godoc.org to pkg.go.dev.
These badges keep working (ref. [Redirecting godoc.org requests to pkg.go.dev](https://blog.golang.org/godoc.org-redirect)), but users will get better experience by skipping redirections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
