### PR TITLE
add IoT 1-Click event

### DIFF
--- a/events/iot_1_click.go
+++ b/events/iot_1_click.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package events
+
+// IoTOneClickEvent represents a click event published by clicking button type
+// device.
+type IoTOneClickEvent struct {
+	DeviceEvent   IoTOneClickDeviceEvent   `json:"deviceEvent"`
+	DeviceInfo    IoTOneClickDeviceInfo    `json:"deviceInfo"`
+	PlacementInfo IoTOneClickPlacementInfo `json:"placementInfo"`
+}
+
+type IoTOneClickDeviceEvent struct {
+	ButtonClicked IoTOneClickButtonClicked `json:"buttonClicked"`
+}
+
+type IoTOneClickButtonClicked struct {
+	ClickType    string `json:"clickType"`
+	ReportedTime string `json:"reportedTime"`
+}
+
+type IoTOneClickDeviceInfo struct {
+	Attributes    map[string]string `json:"attributes"`
+	Type          string            `json:"type"`
+	DeviceID      string            `json:"deviceId"`
+	RemainingLife float64           `json:"remainingLife"`
+}
+
+type IoTOneClickPlacementInfo struct {
+	ProjectName   string            `json:"projectName"`
+	PlacementName string            `json:"placementName"`
+	Attributes    map[string]string `json:"attributes"`
+	Devices       map[string]string `json:"devices"`
+}

--- a/events/iot_1_click_test.go
+++ b/events/iot_1_click_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIoTOneClickEventMalformedJson(t *testing.T) {
+
+	// 1. read JSON from file
+	inputJson := test.ReadJSONFromFile(t, "./testdata/iot-1-click-event.json")
+
+	// 2. de-serialize into Go object
+	var inputEvent IoTOneClickEvent
+	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// 3. serialize to JSON
+	outputJson, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+	// 4. check result
+	assert.JSONEq(t, string(inputJson), string(outputJson))
+}
+
+func TestIoTOneClickEventMarshaling(t *testing.T) {
+	test.TestMalformedJson(t, IoTOneClickEvent{})
+}

--- a/events/testdata/iot-1-click-event.json
+++ b/events/testdata/iot-1-click-event.json
@@ -1,0 +1,29 @@
+{
+  "deviceEvent": {
+    "buttonClicked": {
+      "clickType": "SINGLE",
+      "reportedTime": "2018-05-04T23:26:33.747Z"
+    }
+  },
+  "deviceInfo": {
+    "attributes": {
+      "key3": "value3",
+      "key1": "value1",
+      "key4": "value4"
+    },
+    "type": "button",
+    "deviceId": "G030PMXXXXXXXXXX",
+    "remainingLife": 5.00
+  },
+  "placementInfo": {
+    "projectName": "test",
+    "placementName": "myPlacement",
+    "attributes": {
+      "location": "Seattle",
+      "equipment": "printer"
+    },
+    "devices": {
+      "myButton": "G030PMXXXXXXXXXX"
+    }
+  }
+}


### PR DESCRIPTION
Add event struct for IoT 1-Click ( https://docs.aws.amazon.com/iot-1-click/latest/developerguide/1click-programming.html ).
I assume that we can type the event for lambda handler using this event struct.

```golang
import (
  	"github.com/aws/aws-lambda-go/lambda"
	"github.com/aws/aws-lambda-go/events"
)

func handleRequest(ctx context.Context, event events.IoTOneClickEvent) {
	...
}

func main() {
	lambda.Start(handleRequest)
}
```

I used the sample JSON on the below page to specify the JSON structure.
https://docs.aws.amazon.com/iot-1-click/latest/developerguide/1click-programming.html#1click-events