### PR TITLE
Allow non-string value in body response for api gateway

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -23,7 +23,7 @@ type APIGatewayProxyResponse struct {
 	StatusCode        int                 `json:"statusCode"`
 	Headers           map[string]string   `json:"headers"`
 	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
-	Body              string              `json:"body"`
+	Body              interface{}         `json:"body"`
 	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 }
 
@@ -123,7 +123,7 @@ type APIGatewayV2HTTPResponse struct {
 	StatusCode        int                 `json:"statusCode"`
 	Headers           map[string]string   `json:"headers"`
 	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
-	Body              string              `json:"body"`
+	Body              interface{}         `json:"body"`
 	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 	Cookies           []string            `json:"cookies"`
 }


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*

change data type for `body` in `APIGatewayProxyResponse` and `APIGatewayV2HTTPResponse` struct to interface so it will be more flexible to return the data, instead of only able to return it as a string. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
