### PR TITLE
Add API Gateway V2 custom authorizer simple response type

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -288,7 +288,7 @@ type APIGatewayCustomAuthorizerResponse struct {
 // APIGatewayV2CustomAuthorizerSimpleResponse represents the simple format of an API Gateway V2 authorization response.
 type APIGatewayV2CustomAuthorizerSimpleResponse struct {
 	IsAuthorized bool                   `json:"isAuthorized"`
-	Context      map[string]interface{} `json:"context"`
+	Context      map[string]interface{} `json:"context,omitempty"`
 }
 
 // APIGatewayCustomAuthorizerPolicy represents an IAM policy

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -285,6 +285,12 @@ type APIGatewayCustomAuthorizerResponse struct {
 	UsageIdentifierKey string                           `json:"usageIdentifierKey,omitempty"`
 }
 
+// APIGatewayV2CustomAuthorizerSimpleResponse represents the simple format of an API Gateway V2 authorization response.
+type APIGatewayV2CustomAuthorizerSimpleResponse struct {
+	IsAuthorized bool                   `json:"isAuthorized"`
+	Context      map[string]interface{} `json:"context"`
+}
+
 // APIGatewayCustomAuthorizerPolicy represents an IAM policy
 type APIGatewayCustomAuthorizerPolicy struct {
 	Version   string

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -186,6 +186,7 @@ func TestAPIGatewayV2CustomAuthorizerSimpleResponseMarshalling(t *testing.T) {
 		{"defaults", APIGatewayV2CustomAuthorizerSimpleResponse{}, `{"isAuthorized":false}`},
 		{"without context", APIGatewayV2CustomAuthorizerSimpleResponse{IsAuthorized: true}, `{"isAuthorized":true}`},
 		{"context is nil", APIGatewayV2CustomAuthorizerSimpleResponse{Context: nil}, `{"isAuthorized":false}`},
+		{"context is empty", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{}}, `{"isAuthorized":false}`},
 		{"context with basic types", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"string": "value", "bool": true, "number": 1234}}, `{"isAuthorized":false,"context":{"string":"value","bool":true,"number":1234}}`},
 		{"context with array", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"array": []string{"value1", "value2"}}}, `{"isAuthorized":false,"context":{"array":["value1","value2"]}}`},
 		{"context with map", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"map": map[string]string{"key": "value"}}}, `{"isAuthorized":false,"context":{"map":{"key":"value"}}}`},

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -194,6 +194,7 @@ func TestAPIGatewayV2CustomAuthorizerSimpleResponseMarshalling(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			outputJSON, err := json.Marshal(tt.in)
 			if err != nil {

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -183,14 +183,46 @@ func TestAPIGatewayV2CustomAuthorizerSimpleResponseMarshalling(t *testing.T) {
 		in   APIGatewayV2CustomAuthorizerSimpleResponse
 		out  string
 	}{
-		{"defaults", APIGatewayV2CustomAuthorizerSimpleResponse{}, `{"isAuthorized":false}`},
-		{"without context", APIGatewayV2CustomAuthorizerSimpleResponse{IsAuthorized: true}, `{"isAuthorized":true}`},
-		{"context is nil", APIGatewayV2CustomAuthorizerSimpleResponse{Context: nil}, `{"isAuthorized":false}`},
-		{"context is empty", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{}}, `{"isAuthorized":false}`},
-		{"context with basic types", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"string": "value", "bool": true, "number": 1234}}, `{"isAuthorized":false,"context":{"string":"value","bool":true,"number":1234}}`},
-		{"context with array", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"array": []string{"value1", "value2"}}}, `{"isAuthorized":false,"context":{"array":["value1","value2"]}}`},
-		{"context with map", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"map": map[string]string{"key": "value"}}}, `{"isAuthorized":false,"context":{"map":{"key":"value"}}}`},
-		{"context with nil value", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"nil": nil}}, `{"isAuthorized":false,"context":{"nil":null}}`},
+		{
+			"defaults",
+			APIGatewayV2CustomAuthorizerSimpleResponse{},
+			`{"isAuthorized":false}`,
+		},
+		{
+			"without context",
+			APIGatewayV2CustomAuthorizerSimpleResponse{IsAuthorized: true},
+			`{"isAuthorized":true}`,
+		},
+		{
+			"context is nil",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: nil},
+			`{"isAuthorized":false}`,
+		},
+		{
+			"context is empty",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{}},
+			`{"isAuthorized":false}`,
+		},
+		{
+			"context with basic types",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"string": "value", "bool": true, "number": 1234}},
+			`{"isAuthorized":false,"context":{"string":"value","bool":true,"number":1234}}`,
+		},
+		{
+			"context with array",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"array": []string{"value1", "value2"}}},
+			`{"isAuthorized":false,"context":{"array":["value1","value2"]}}`,
+		},
+		{
+			"context with map",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"map": map[string]string{"key": "value"}}},
+			`{"isAuthorized":false,"context":{"map":{"key":"value"}}}`,
+		},
+		{
+			"context with nil value",
+			APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"nil": nil}},
+			`{"isAuthorized":false,"context":{"nil":null}}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -177,6 +177,33 @@ func TestApiGatewayCustomAuthorizerResponseMarshaling(t *testing.T) {
 	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
+func TestAPIGatewayV2CustomAuthorizerSimpleResponseMarshalling(t *testing.T) {
+	var tests = []struct {
+		desc string
+		in   APIGatewayV2CustomAuthorizerSimpleResponse
+		out  string
+	}{
+		{"defaults", APIGatewayV2CustomAuthorizerSimpleResponse{}, `{"isAuthorized":false}`},
+		{"without context", APIGatewayV2CustomAuthorizerSimpleResponse{IsAuthorized: true}, `{"isAuthorized":true}`},
+		{"context is nil", APIGatewayV2CustomAuthorizerSimpleResponse{Context: nil}, `{"isAuthorized":false}`},
+		{"context with basic types", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"string": "value", "bool": true, "number": 1234}}, `{"isAuthorized":false,"context":{"string":"value","bool":true,"number":1234}}`},
+		{"context with array", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"array": []string{"value1", "value2"}}}, `{"isAuthorized":false,"context":{"array":["value1","value2"]}}`},
+		{"context with map", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"map": map[string]string{"key": "value"}}}, `{"isAuthorized":false,"context":{"map":{"key":"value"}}}`},
+		{"context with nil value", APIGatewayV2CustomAuthorizerSimpleResponse{Context: map[string]interface{}{"nil": nil}}, `{"isAuthorized":false,"context":{"nil":null}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			outputJSON, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Errorf("could not marshal event. details: %v", err)
+			}
+
+			assert.JSONEq(t, tt.out, string(outputJSON))
+		})
+	}
+}
+
 func TestApiGatewayCustomAuthorizerResponseMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, APIGatewayCustomAuthorizerResponse{})
 }


### PR DESCRIPTION
*Issue #369, #372:*

*Description of changes:*

This PR adds the missing type for API Gateway V2 custom authorizer simple response. See: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format-response


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
