### PR TITLE
Add AppSync Lambda Authorizer Events

### DIFF
--- a/events/appsync.go
+++ b/events/appsync.go
@@ -38,3 +38,28 @@ const (
 	// OperationBatchInvoke instructs AWS AppSync to batch requests for the current GraphQL field
 	OperationBatchInvoke AppSyncOperation = "BatchInvoke"
 )
+
+// AppSyncLambdaAuthorizerRequest contains an authorization request from AppSync.
+type AppSyncLambdaAuthorizerRequest struct {
+	AuthorizationToken string                                `json:"authorizationToken"`
+	RequestContext     AppSyncLambdaAuthorizerRequestContext `json:"requestContext"`
+}
+
+// AppSyncLambdaAuthorizerRequestContext contains the parameters of the AppSync invocation which triggered
+// this authorization request.
+type AppSyncLambdaAuthorizerRequestContext struct {
+	APIID         string                 `json:"apiId"`
+	AccountID     string                 `json:"accountId"`
+	RequestID     string                 `json:"requestId"`
+	QueryString   string                 `json:"queryString"`
+	OperationName string                 `json:"operationName"`
+	Variables     map[string]interface{} `json:"variables"`
+}
+
+// AppSyncLambdaAuthorizerResponse represents the expected format of an authorization request from AppSync.
+type AppSyncLambdaAuthorizerResponse struct {
+	IsAuthorized    bool                   `json:"isAuthorized"`
+	ResolverContext map[string]interface{} `json:"resolverContext,omitempty"`
+	DeniedFields    []string               `json:"deniedFields,omitempty"`
+	TTLOverride     *int                   `json:"ttlOverride,omitempty"`
+}

--- a/events/appsync.go
+++ b/events/appsync.go
@@ -56,7 +56,7 @@ type AppSyncLambdaAuthorizerRequestContext struct {
 	Variables     map[string]interface{} `json:"variables"`
 }
 
-// AppSyncLambdaAuthorizerResponse represents the expected format of an authorization request from AppSync.
+// AppSyncLambdaAuthorizerResponse represents the expected format of an authorization response to AppSync.
 type AppSyncLambdaAuthorizerResponse struct {
 	IsAuthorized    bool                   `json:"isAuthorized"`
 	ResolverContext map[string]interface{} `json:"resolverContext,omitempty"`

--- a/events/appsync_test.go
+++ b/events/appsync_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/aws/aws-lambda-go/events/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,4 +85,50 @@ func TestAppSyncIdentity_Cognito(t *testing.T) {
 	}
 
 	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestAppSyncLambdaAuthorizerRequestMarshalling(t *testing.T) {
+	inputJSON, err := ioutil.ReadFile("./testdata/appsync-lambda-auth-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	var inputEvent AppSyncLambdaAuthorizerRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestAppSyncLambdaAuthorizerRequestMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, AppSyncLambdaAuthorizerRequest{})
+}
+
+func TestAppSyncLambdaAuthorizerResponseMarshalling(t *testing.T) {
+	inputJSON, err := ioutil.ReadFile("./testdata/appsync-lambda-auth-response.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	var inputEvent AppSyncLambdaAuthorizerResponse
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestAppSyncLambdaAuthorizerResponseMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, AppSyncLambdaAuthorizerResponse{})
 }

--- a/events/testdata/appsync-lambda-auth-request.json
+++ b/events/testdata/appsync-lambda-auth-request.json
@@ -1,0 +1,11 @@
+{
+    "authorizationToken": "ExampleAUTHtoken123123123",
+    "requestContext": {
+        "apiId": "aaaaaa123123123example123",
+        "accountId": "111122223333",
+        "requestId": "f4081827-1111-4444-5555-5cf4695f339f",
+        "queryString": "mutation CreateEvent {...}\n\nquery MyQuery {...}\n",
+        "operationName": "MyQuery",
+        "variables": {}
+    }
+}

--- a/events/testdata/appsync-lambda-auth-response.json
+++ b/events/testdata/appsync-lambda-auth-response.json
@@ -1,0 +1,7 @@
+{
+    "isAuthorized": true,
+    "resolverContext": {
+        "banana": "very yellow",
+        "apple": "very green"
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
Support for [Lambda Authorizers](https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization) in AppSync.

*Description of changes:*
Adds `AppSyncLambdaAuthorizerRequest`/`AppSyncLambdaAuthorizerResponse` events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
