### PR TITLE
enable stylecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,4 +23,4 @@ linters-settings:
   stylecheck:
     go: "1.17"
     checks: ["all"]
-    initialisims: ["AWS", "ARN", "IAM", "MQTT", "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
+    initialisms: ["AWS", "ARN", "IAM", "MQTT", "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,15 @@ linters:
     - typecheck
     - unused
     - varcheck
+    - stylecheck
 
 run:
   skip-files:
     # These were code-generated, and cannot be changed without breaking RPC compatibility.
     - lambda/messages/*.go
+
+linters-settings:
+  stylecheck:
+    go: "1.17"
+    checks: ["all"]
+    initialisims: ["AWS", "ARN", "MQTT", "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,4 +23,4 @@ linters-settings:
   stylecheck:
     go: "1.17"
     checks: ["all"]
-    initialisims: ["AWS", "ARN", "MQTT", "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
+    initialisims: ["AWS", "ARN", "IAM", "MQTT", "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]

--- a/events/activemq_test.go
+++ b/events/activemq_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestActiveMQEventMarshaling(t *testing.T) {
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/activemq-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/activemq-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent ActiveMQEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
@@ -32,13 +32,13 @@ func TestActiveMQEventMarshaling(t *testing.T) {
 	assert.Equal(t, false, message.Redelivered)
 
 	// 4. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 5. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestActiveMQMarshalingMalformedJson(t *testing.T) {

--- a/events/alb.go
+++ b/events/alb.go
@@ -20,7 +20,7 @@ type ALBTargetGroupRequestContext struct {
 
 // ELBContext contains the information to identify the ARN invoking the lambda
 type ELBContext struct {
-	TargetGroupArn string `json:"targetGroupArn"`
+	TargetGroupArn string `json:"targetGroupArn"` //nolint: stylecheck
 }
 
 // ALBTargetGroupResponse configures the response to be returned by the ALB Lambda target group for the request

--- a/events/apigw.go
+++ b/events/apigw.go
@@ -141,7 +141,7 @@ type APIGatewayRequestIdentity struct {
 	SourceIP                      string `json:"sourceIp"`
 	CognitoAuthenticationType     string `json:"cognitoAuthenticationType"`
 	CognitoAuthenticationProvider string `json:"cognitoAuthenticationProvider"`
-	UserArn                       string `json:"userArn"`
+	UserArn                       string `json:"userArn"` //nolint: stylecheck
 	UserAgent                     string `json:"userAgent"`
 	User                          string `json:"user"`
 }
@@ -258,13 +258,13 @@ type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
 type APIGatewayCustomAuthorizerRequest struct {
 	Type               string `json:"type"`
 	AuthorizationToken string `json:"authorizationToken"`
-	MethodArn          string `json:"methodArn"`
+	MethodArn          string `json:"methodArn"` //nolint: stylecheck
 }
 
 // APIGatewayCustomAuthorizerRequestTypeRequest contains data coming in to a custom API Gateway authorizer function.
 type APIGatewayCustomAuthorizerRequestTypeRequest struct {
 	Type                            string                                              `json:"type"`
-	MethodArn                       string                                              `json:"methodArn"`
+	MethodArn                       string                                              `json:"methodArn"` //nolint: stylecheck
 	Resource                        string                                              `json:"resource"`
 	Path                            string                                              `json:"path"`
 	HTTPMethod                      string                                              `json:"httpMethod"`

--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -20,7 +20,7 @@ type DynamoDBAttributeValue struct {
 
 // This struct represents DynamoDBAttributeValue which doesn't
 // implement fmt.Stringer interface and safely `fmt.Sprintf`able
-type dynamoDbAttributeValue DynamoDBAttributeValue
+type dynamoDbAttributeValue DynamoDBAttributeValue //nolint: stylecheck
 
 // Binary provides access to an attribute of type Binary.
 // Method panics if the attribute is not of type Binary.

--- a/events/autoscaling_test.go
+++ b/events/autoscaling_test.go
@@ -18,20 +18,20 @@ func TestAutoScalingEventMarshaling(t *testing.T) {
 
 		t.Logf("Running test for %s\n", sampleFile)
 		// 1. read JSON from file
-		inputJson := test.ReadJSONFromFile(t, "./testdata/"+sampleFile)
+		inputJSON := test.ReadJSONFromFile(t, "./testdata/"+sampleFile)
 
 		// 2. de-serialize into Go object
 		var inputEvent AutoScalingEvent
-		if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+		if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 			t.Errorf("could not unmarshal event. details: %v", err)
 		}
 		// 3. serialize to JSON
-		outputJson, err := json.Marshal(inputEvent)
+		outputJSON, err := json.Marshal(inputEvent)
 		if err != nil {
 			t.Errorf("could not marshal event. details: %v", err)
 		}
 		// 4. check result
-		assert.JSONEq(t, string(inputJson), string(outputJson))
+		assert.JSONEq(t, string(inputJSON), string(outputJSON))
 	}
 
 }

--- a/events/cloudwatch_logs_test.go
+++ b/events/cloudwatch_logs_test.go
@@ -11,7 +11,7 @@ import (
 func TestCloudwatchLogs(t *testing.T) {
 	for _, test := range []struct {
 		name                      string
-		eventJson                 string
+		eventJSON                 string
 		expectError               bool
 		expectCloudwatchEventData CloudwatchLogsEvent
 	}{
@@ -27,10 +27,10 @@ func TestCloudwatchLogs(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			inputJson := tst.ReadJSONFromFile(t, test.eventJson)
+			inputJSON := tst.ReadJSONFromFile(t, test.eventJSON)
 
 			var inputEvent CloudwatchLogsEvent
-			err := json.Unmarshal(inputJson, &inputEvent)
+			err := json.Unmarshal(inputJSON, &inputEvent)
 
 			if err != nil && !test.expectError {
 				t.Errorf("could not unmarshal event. details: %v", err)
@@ -50,7 +50,7 @@ func TestCloudwatchLogs(t *testing.T) {
 func TestCloudwatchLogsParse(t *testing.T) {
 	for _, test := range []struct {
 		name                     string
-		eventJson                string
+		eventJSON                string
 		expectError              bool
 		expectCloudwatchLogsData CloudwatchLogsData
 	}{
@@ -74,10 +74,10 @@ func TestCloudwatchLogsParse(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			inputJson := tst.ReadJSONFromFile(t, test.eventJson)
+			inputJSON := tst.ReadJSONFromFile(t, test.eventJSON)
 
 			var inputEvent CloudwatchLogsEvent
-			if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+			if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 				t.Errorf("could not unmarshal event. details: %v", err)
 			}
 

--- a/events/code_commit.go
+++ b/events/code_commit.go
@@ -52,7 +52,7 @@ type CodeCommitRecord struct {
 	EventPartNumber      uint64               `json:"eventPartNumber"`
 	CodeCommit           CodeCommitCodeCommit `json:"codecommit"`
 	EventName            string               `json:"eventName"`
-	EventTriggerConfigId string               `json:"eventTriggerConfigId"`
+	EventTriggerConfigId string               `json:"eventTriggerConfigId"` //nolint: stylecheck
 	EventSourceARN       string               `json:"eventSourceARN"`
 	UserIdentityARN      string               `json:"userIdentityARN"`
 	EventSource          string               `json:"eventSource"`

--- a/events/config.go
+++ b/events/config.go
@@ -4,14 +4,21 @@ package events
 
 // ConfigEvent contains data from an event sent from AWS Config
 type ConfigEvent struct {
-	AccountID        string `json:"accountId"`     // The ID of the AWS account that owns the rule
-	ConfigRuleArn    string `json:"configRuleArn"` // The ARN that AWS Config assigned to the rule
-	ConfigRuleID     string `json:"configRuleId"`
-	ConfigRuleName   string `json:"configRuleName"` // The name that you assigned to the rule that caused AWS Config to publish the event
-	EventLeftScope   bool   `json:"eventLeftScope"` // A boolean value that indicates whether the AWS resource to be evaluated has been removed from the rule's scope
-	ExecutionRoleArn string `json:"executionRoleArn"`
-	InvokingEvent    string `json:"invokingEvent"`  // If the event is published in response to a resource configuration change, this value contains a JSON configuration item
-	ResultToken      string `json:"resultToken"`    // A token that the function must pass to AWS Config with the PutEvaluations call
-	RuleParameters   string `json:"ruleParameters"` // Key/value pairs that the function processes as part of its evaluation logic
-	Version          string `json:"version"`
+	// The ID of the AWS account that owns the rule
+	AccountID string `json:"accountId"`
+	// The ARN that AWS Config assigned to the rule
+	ConfigRuleArn string `json:"configRuleArn"` //nolint:stylecheck
+	ConfigRuleID  string `json:"configRuleId"`  //nolint:stylecheck
+	// The name that you assigned to the rule that caused AWS Config to publish the event
+	ConfigRuleName string `json:"configRuleName"`
+	// A boolean value that indicates whether the AWS resource to be evaluated has been removed from the rule's scope
+	EventLeftScope   bool   `json:"eventLeftScope"`
+	ExecutionRoleArn string `json:"executionRoleArn"` //nolint:stylecheck
+	// If the event is published in response to a resource configuration change, this value contains a JSON configuration item
+	InvokingEvent string `json:"invokingEvent"`
+	// A token that the function must pass to AWS Config with the PutEvaluations call
+	ResultToken string `json:"resultToken"`
+	// Key/value pairs that the function processes as part of its evaluation logic
+	RuleParameters string `json:"ruleParameters"`
+	Version        string `json:"version"`
 }

--- a/events/connect_test.go
+++ b/events/connect_test.go
@@ -13,22 +13,22 @@ import (
 func TestConnectMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/connect-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/connect-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent ConnectEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestConnectMarshalingMalformedJson(t *testing.T) {

--- a/events/dynamodb.go
+++ b/events/dynamodb.go
@@ -43,7 +43,7 @@ type DynamoDBEventRecord struct {
 	EventVersion string `json:"eventVersion"`
 
 	// The event source ARN of DynamoDB
-	EventSourceArn string `json:"eventSourceARN"`
+	EventSourceArn string `json:"eventSourceARN"` //nolint: stylecheck
 
 	// Items that are deleted by the Time to Live process after expiration have
 	// the following fields:

--- a/events/dynamodb_test.go
+++ b/events/dynamodb_test.go
@@ -13,22 +13,22 @@ import (
 func TestDynamoDBEventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/dynamodb-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/dynamodb-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent DynamoDBEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestDynamoDBEventMarshalingMalformedJson(t *testing.T) {

--- a/events/ecr_scan_test.go
+++ b/events/ecr_scan_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestECRScanEventMarshaling(t *testing.T) {
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/ecr-image-scan-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/ecr-image-scan-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent ECRScanEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
@@ -42,13 +42,13 @@ func TestECRScanEventMarshaling(t *testing.T) {
 	assert.Equal(t, int64(0), detail.FindingSeverityCounts.Undefined)
 
 	// 4. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 5. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestECRScanMarshalingMalformedJson(t *testing.T) {

--- a/events/firehose.go
+++ b/events/firehose.go
@@ -5,8 +5,8 @@ package events
 // KinesisFirehoseEvent represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
 type KinesisFirehoseEvent struct {
 	InvocationID           string                       `json:"invocationId"`
-	DeliveryStreamArn      string                       `json:"deliveryStreamArn"`
-	SourceKinesisStreamArn string                       `json:"sourceKinesisStreamArn"`
+	DeliveryStreamArn      string                       `json:"deliveryStreamArn"`      //nolint: stylecheck
+	SourceKinesisStreamArn string                       `json:"sourceKinesisStreamArn"` //nolint: stylecheck
 	Region                 string                       `json:"region"`
 	Records                []KinesisFirehoseEventRecord `json:"records"`
 }

--- a/events/firehose_test.go
+++ b/events/firehose_test.go
@@ -21,29 +21,29 @@ func TestFirehoseResponseMarshaling(t *testing.T) {
 
 func testMarshaling(t *testing.T, inputEvent interface{}, jsonFile string) {
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, jsonFile)
+	inputJSON := test.ReadJSONFromFile(t, jsonFile)
 
 	// 2. de-serialize into Go object
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestSampleTransformation(t *testing.T) {
-	inputJson := test.ReadJSONFromFile(t, "./testdata/kinesis-firehose-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/kinesis-firehose-event.json")
 
 	// de-serialize into Go object
 	var inputEvent KinesisFirehoseEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 

--- a/events/iot_1_click_test.go
+++ b/events/iot_1_click_test.go
@@ -12,21 +12,21 @@ import (
 func TestIoTOneClickEventMalformedJson(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/iot-1-click-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/iot-1-click-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent IoTOneClickEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestIoTOneClickEventMarshaling(t *testing.T) {

--- a/events/iot_button_test.go
+++ b/events/iot_button_test.go
@@ -12,21 +12,21 @@ import (
 func TestIoTButtonMalformedJson(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/iot-button-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/iot-button-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent IoTButtonEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestIoTButtonEventMarshaling(t *testing.T) {

--- a/events/kafka_test.go
+++ b/events/kafka_test.go
@@ -12,11 +12,11 @@ import (
 func TestKafkaEventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/kafka-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/kafka-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent KafkaEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
@@ -33,7 +33,7 @@ func TestKafkaEventMarshaling(t *testing.T) {
 			for _, header := range record.Headers {
 				for key, value := range header {
 					assert.Equal(t, key, "headerKey")
-					var headerValue string = string(value)
+					headerValue := string(value)
 					assert.Equal(t, headerValue, "headerValue")
 				}
 			}
@@ -41,13 +41,13 @@ func TestKafkaEventMarshaling(t *testing.T) {
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestKafkaMarshalingMalformedJson(t *testing.T) {

--- a/events/kinesis.go
+++ b/events/kinesis.go
@@ -7,13 +7,13 @@ type KinesisEvent struct {
 }
 
 type KinesisEventRecord struct {
-	AwsRegion         string        `json:"awsRegion"`
+	AwsRegion         string        `json:"awsRegion"` //nolint: stylecheck
 	EventID           string        `json:"eventID"`
 	EventName         string        `json:"eventName"`
 	EventSource       string        `json:"eventSource"`
-	EventSourceArn    string        `json:"eventSourceARN"`
+	EventSourceArn    string        `json:"eventSourceARN"` //nolint: stylecheck
 	EventVersion      string        `json:"eventVersion"`
-	InvokeIdentityArn string        `json:"invokeIdentityArn"`
+	InvokeIdentityArn string        `json:"invokeIdentityArn"` //nolint: stylecheck
 	Kinesis           KinesisRecord `json:"kinesis"`
 }
 

--- a/events/kinesis_test.go
+++ b/events/kinesis_test.go
@@ -12,22 +12,22 @@ import (
 func TestKinesisEventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/kinesis-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/kinesis-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent KinesisEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestKinesisMarshalingMalformedJson(t *testing.T) {

--- a/events/s3.go
+++ b/events/s3.go
@@ -44,7 +44,7 @@ type S3Entity struct {
 type S3Bucket struct {
 	Name          string         `json:"name"`
 	OwnerIdentity S3UserIdentity `json:"ownerIdentity"`
-	Arn           string         `json:"arn"`
+	Arn           string         `json:"arn"` //nolint: stylecheck
 }
 
 type S3Object struct {

--- a/events/sns.go
+++ b/events/sns.go
@@ -12,7 +12,7 @@ type SNSEvent struct {
 
 type SNSEventRecord struct {
 	EventVersion         string    `json:"EventVersion"`
-	EventSubscriptionArn string    `json:"EventSubscriptionArn"`
+	EventSubscriptionArn string    `json:"EventSubscriptionArn"` //nolint: stylecheck
 	EventSource          string    `json:"EventSource"`
 	SNS                  SNSEntity `json:"Sns"`
 }
@@ -21,7 +21,7 @@ type SNSEntity struct {
 	Signature         string                 `json:"Signature"`
 	MessageID         string                 `json:"MessageId"`
 	Type              string                 `json:"Type"`
-	TopicArn          string                 `json:"TopicArn"`
+	TopicArn          string                 `json:"TopicArn"` //nolint: stylecheck
 	MessageAttributes map[string]interface{} `json:"MessageAttributes"`
 	SignatureVersion  string                 `json:"SignatureVersion"`
 	Timestamp         time.Time              `json:"Timestamp"`

--- a/events/sns_test.go
+++ b/events/sns_test.go
@@ -12,22 +12,22 @@ import (
 func TestSnsEventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/sns-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/sns-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent SNSEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestSnsMarshalingMalformedJson(t *testing.T) {
@@ -36,11 +36,11 @@ func TestSnsMarshalingMalformedJson(t *testing.T) {
 
 func TestCloudWatchAlarmSNSPayloadMarshaling(t *testing.T) {
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/cloudwatch-alarm-sns-payload-single-metric.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/cloudwatch-alarm-sns-payload-single-metric.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent SNSEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
@@ -54,11 +54,11 @@ func TestCloudWatchAlarmSNSPayloadMarshaling(t *testing.T) {
 	}
 
 	// 5. serialize message to JSON
-	outputJson, err := json.Marshal(inputCloudWatchPayload)
+	outputJSON, err := json.Marshal(inputCloudWatchPayload)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(message), string(outputJson))
+	assert.JSONEq(t, string(message), string(outputJSON))
 }

--- a/events/sqs.go
+++ b/events/sqs.go
@@ -7,7 +7,7 @@ type SQSEvent struct {
 }
 
 type SQSMessage struct {
-	MessageId              string                         `json:"messageId"`
+	MessageId              string                         `json:"messageId"` //nolint: stylecheck
 	ReceiptHandle          string                         `json:"receiptHandle"`
 	Body                   string                         `json:"body"`
 	Md5OfBody              string                         `json:"md5OfBody"`

--- a/events/sqs_test.go
+++ b/events/sqs_test.go
@@ -12,22 +12,22 @@ import (
 func TestSqsEventMarshaling(t *testing.T) {
 
 	// 1. read JSON from file
-	inputJson := test.ReadJSONFromFile(t, "./testdata/sqs-event.json")
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/sqs-event.json")
 
 	// 2. de-serialize into Go object
 	var inputEvent SQSEvent
-	if err := json.Unmarshal(inputJson, &inputEvent); err != nil {
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
 		t.Errorf("could not unmarshal event. details: %v", err)
 	}
 
 	// 3. serialize to JSON
-	outputJson, err := json.Marshal(inputEvent)
+	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {
 		t.Errorf("could not marshal event. details: %v", err)
 	}
 
 	// 4. check result
-	assert.JSONEq(t, string(inputJson), string(outputJson))
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
 func TestSqsMarshalingMalformedJson(t *testing.T) {

--- a/events/test/assert.go
+++ b/events/test/assert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint: stylecheck
 func AssertJsonFile(t *testing.T, file string, o interface{}) {
 	inputJSON, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -16,6 +17,7 @@ func AssertJsonFile(t *testing.T, file string, o interface{}) {
 	AssertJsonBytes(t, inputJSON, o)
 }
 
+//nolint: stylecheck
 func AssertJsonBytes(t *testing.T, inputJSON []byte, o interface{}) {
 	// de-serialize
 	if err := json.Unmarshal(inputJSON, o); err != nil {

--- a/events/test/jsonblobs.go
+++ b/events/test/jsonblobs.go
@@ -1,5 +1,6 @@
 package test
 
+//nolint: stylecheck
 func GetMalformedJson() []byte {
 	return []byte(`{ "Records`)
 }

--- a/events/test/jsoncompare.go
+++ b/events/test/jsoncompare.go
@@ -10,6 +10,6 @@ import (
 
 // AssertJsonsEqual asserts two JSON files are semantically equal
 // (ignores white-space and attribute order)
-func AssertJsonsEqual(t *testing.T, expectedJson []byte, actualJson []byte) {
-	assert.JSONEq(t, string(expectedJson), string(actualJson))
+func AssertJsonsEqual(t *testing.T, expectedJSON []byte, actualJSON []byte) {
+	assert.JSONEq(t, string(expectedJSON), string(actualJSON))
 }

--- a/events/test/jsonsyntax.go
+++ b/events/test/jsonsyntax.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 )
 
+//nolint: stylecheck
 func TestMalformedJson(t *testing.T, objectToDeserialize interface{}) {
 	// 1. read JSON from file
 	inputJson := GetMalformedJson()

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -54,6 +54,7 @@ func TestInvalidHandlers(t *testing.T) {
 		{
 			name:     "handler returning two values does not declare error as the second return value",
 			expected: errors.New("handler returns two values, but the second does not implement error"),
+			//nolint: stylecheck
 			handler: func() (error, string) {
 				return nil, "hello"
 			},

--- a/lambda/messages/messages.go
+++ b/lambda/messages/messages.go
@@ -10,19 +10,21 @@ type PingRequest struct {
 type PingResponse struct {
 }
 
+//nolint:stylecheck
 type InvokeRequest_Timestamp struct {
 	Seconds int64
 	Nanos   int64
 }
 
+//nolint:stylecheck
 type InvokeRequest struct {
 	Payload               []byte
-	RequestId             string
+	RequestId             string //nolint:stylecheck
 	XAmznTraceId          string
 	Deadline              InvokeRequest_Timestamp
 	InvokedFunctionArn    string
-	CognitoIdentityId     string
-	CognitoIdentityPoolId string
+	CognitoIdentityId     string //nolint:stylecheck
+	CognitoIdentityPoolId string //nolint:stylecheck
 	ClientContext         []byte
 }
 
@@ -31,6 +33,7 @@ type InvokeResponse struct {
 	Error   *InvokeResponse_Error
 }
 
+//nolint:stylecheck
 type InvokeResponse_Error struct {
 	Message    string                             `json:"errorMessage"`
 	Type       string                             `json:"errorType"`
@@ -42,6 +45,7 @@ func (e InvokeResponse_Error) Error() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+//nolint:stylecheck
 type InvokeResponse_Error_StackFrame struct {
 	Path  string `json:"path"`
 	Line  int32  `json:"line"`

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -122,7 +122,7 @@ func (c *runtimeAPIClient) post(url string, payload []byte, contentType string) 
 		}
 	}()
 
-	if 202 != resp.StatusCode {
+	if resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("failed to POST to %s: got unexpected status code: %d", url, resp.StatusCode)
 	}
 

--- a/lambdacontext/context.go
+++ b/lambdacontext/context.go
@@ -62,8 +62,8 @@ type CognitoIdentity struct {
 
 // LambdaContext is the set of metadata that is passed for every Invoke.
 type LambdaContext struct {
-	AwsRequestID       string
-	InvokedFunctionArn string
+	AwsRequestID       string //nolint: stylecheck
+	InvokedFunctionArn string //nolint: stylecheck
 	Identity           CognitoIdentity
 	ClientContext      ClientContext
 }


### PR DESCRIPTION
*Description of changes:*

I give a lot of feedback on field naming consistency - enabling and configuring the stylecheck linter will help capture the majority of this feedback automatically

This required back-filling `//nolint: stylecheck` into all the places where there was an inconsistency that can't be fixed without breaking API compatibility


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
