### PR TITLE
add source-version to additional information in codebuild details

### DIFF
--- a/events/codebuild.go
+++ b/events/codebuild.go
@@ -109,6 +109,8 @@ type CodeBuildEventAdditionalInformation struct {
 
 	Source CodeBuildSource `json:"source"`
 
+	SourceVersion string `json:"source-version"`
+
 	Logs CodeBuildLogs `json:"logs"`
 
 	Phases []CodeBuildPhase `json:"phases"`

--- a/events/codebuild_test.go
+++ b/events/codebuild_test.go
@@ -58,6 +58,7 @@ func TestUnmarshalCodeBuildEvent(t *testing.T) {
 							Location: "codebuild-123456789012-input-bucket/my-input-artifact.zip",
 							Type:     "S3",
 						},
+						SourceVersion: "my-source-version",
 						Logs: CodeBuildLogs{
 							GroupName:  "/aws/codebuild/my-sample-project",
 							StreamName: "8745a7a9-c340-456a-9166-edf953571bEX",

--- a/events/testdata/codebuild-state-change.json
+++ b/events/testdata/codebuild-state-change.json
@@ -40,6 +40,7 @@
                 "location": "codebuild-123456789012-input-bucket/my-input-artifact.zip",
                 "type": "S3"
             },
+            "source-version": "my-source-version",
             "logs": {
                 "group-name": "/aws/codebuild/my-sample-project",
                 "stream-name": "8745a7a9-c340-456a-9166-edf953571bEX",
@@ -55,12 +56,12 @@
                     "phase-status": "SUCCEEDED"
                 },
                 {
-                   "phase-context": [],
-                   "start-time": "Sep 1, 2017 4:12:29 PM",
-                   "end-time": "Sep 13, 2019 4:12:29 AM",
-                   "duration-in-seconds": 0.0,
-                   "phase-type": "QUEUED",
-                   "phase-status": "SUCCEEDED"
+                    "phase-context": [],
+                    "start-time": "Sep 1, 2017 4:12:29 PM",
+                    "end-time": "Sep 13, 2019 4:12:29 AM",
+                    "duration-in-seconds": 0.0,
+                    "phase-type": "QUEUED",
+                    "phase-status": "SUCCEEDED"
                 },
                 {
                     "phase-context": [],


### PR DESCRIPTION
This adds the `source-version` to the CodeBuildEventAdditionalInformation struct. The value is the commit id when the source is github or bitbucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
