### PR TITLE
Log function error on failure

### DIFF
--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"time"
 
@@ -47,8 +48,9 @@ func handleInvoke(invoke *invoke, function *Function) error {
 	}
 
 	if functionResponse.Error != nil {
-		payload := safeMarshal(functionResponse.Error)
-		if err := invoke.failure(payload, contentTypeJSON); err != nil {
+		errorPayload := safeMarshal(functionResponse.Error)
+		log.Printf("%s", errorPayload)
+		if err := invoke.failure(errorPayload, contentTypeJSON); err != nil {
 			return fmt.Errorf("unexpected error occurred when sending the function error to the API: %v", err)
 		}
 		if functionResponse.Error.ShouldExit {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-go/issues/411

*Description of changes:*
Log serialized function error when function invocation fails. This change only affects the non-RPC path where the library is used as a standalone Runtime Interface Client.

The error message format is not the same as the `go1.x` runtime, as this one is serialized and includes a timestamp.

Testing:
1. Built the change and tested on `provided.al2` runtime, managed to see error in invocation logs:
```
START RequestId: a3dc012e-ab86-472e-b7ba-da56bfa92e5d Version: $LATEST
2021/12/08 12:33:00 {"errorMessage":"error in CW test","errorType":"errorString"}
END RequestId: a3dc012e-ab86-472e-b7ba-da56bfa92e5d
REPORT RequestId: a3dc012e-ab86-472e-b7ba-da56bfa92e5d  Init Duration: 3.71 ms  Duration: 39.46 ms      Billed Duration: 40 ms  Memory Size: 3008 MB    Max Memory Used: 3008 MB 
```

whereas before this change:
```
START RequestId: 1553ae39-0f8a-4172-86fb-3db7090619e7 Version: $LATEST
END RequestId: 1553ae39-0f8a-4172-86fb-3db7090619e7
REPORT RequestId: 1553ae39-0f8a-4172-86fb-3db7090619e7  Init Duration: 0.60 ms  Duration: 11.00 ms      Billed Duration: 12 ms  Memory Size: 3008 MB    Max Memory Used: 3008 MB        
```

2. Ran on `go1.x` runtime and did not see a change in logged messages:
```
START RequestId: 75337e13-e8d0-48c9-b40b-74c2b7394622 Version: $LATEST
error in CW test: errorString
null
END RequestId: 75337e13-e8d0-48c9-b40b-74c2b7394622
REPORT RequestId: 75337e13-e8d0-48c9-b40b-74c2b7394622  Init Duration: 0.36 ms  Duration: 23.98 ms      Billed Duration: 24 ms  Memory Size: 3008 MB    Max Memory Used: 3008 MB     
```

3. Rebuilt `go1.x` internally with this change, did not see a change in logged message either:
```
START RequestId: 918788fb-1715-4961-ad3f-cc068c120803 Version: $LATEST
error in CW test: errorString
null
END RequestId: 918788fb-1715-4961-ad3f-cc068c120803
REPORT RequestId: 918788fb-1715-4961-ad3f-cc068c120803  Init Duration: 0.47 ms  Duration: 29.90 ms      Billed Duration: 30 ms  Memory Size: 3008 MB    Max Memory Used: 3008 MB       
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
