### PR TITLE
Add missing BuildNumber to CodeBuildEventAdditionalInformation

### DIFF
--- a/events/codebuild.go
+++ b/events/codebuild.go
@@ -103,6 +103,8 @@ type CodeBuildEventAdditionalInformation struct {
 
 	BuildComplete bool `json:"build-complete"`
 
+	BuildNumber int `json:"build-number,omitempty"`
+
 	Initiator string `json:"initiator"`
 
 	BuildStartTime CodeBuildTime `json:"build-start-time"`

--- a/events/codebuild.go
+++ b/events/codebuild.go
@@ -103,7 +103,7 @@ type CodeBuildEventAdditionalInformation struct {
 
 	BuildComplete bool `json:"build-complete"`
 
-	BuildNumber int `json:"build-number,omitempty"`
+	BuildNumber CodeBuildNumber `json:"build-number,omitempty"`
 
 	Initiator string `json:"initiator"`
 
@@ -195,5 +195,24 @@ func (t *CodeBuildTime) UnmarshalJSON(data []byte) error {
 	}
 
 	*t = CodeBuildTime(ts)
+	return nil
+}
+
+// CodeBuildNumber represents the number of the build
+type CodeBuildNumber int32
+
+// MarshalJSON converts a given CodeBuildNumber to json
+func (n CodeBuildNumber) MarshalJSON() ([]byte, error) {
+	return json.Marshal(float32(n))
+}
+
+// UnmarshalJSON converts a given json to a CodeBuildNumber
+func (n *CodeBuildNumber) UnmarshalJSON(data []byte) error {
+	var f float32
+	if err := json.Unmarshal(data, &f); err != nil {
+		return err
+	}
+
+	*n = CodeBuildNumber(int32(f))
 	return nil
 }

--- a/events/codebuild_test.go
+++ b/events/codebuild_test.go
@@ -52,6 +52,7 @@ func TestUnmarshalCodeBuildEvent(t *testing.T) {
 						},
 						Timeout:        DurationMinutes(60 * time.Minute),
 						BuildComplete:  true,
+						BuildNumber:    55,
 						Initiator:      "MyCodeBuildDemoUser",
 						BuildStartTime: CodeBuildTime(time.Date(2017, 9, 1, 16, 12, 29, 0, time.UTC)),
 						Source: CodeBuildSource{
@@ -189,6 +190,7 @@ func TestUnmarshalCodeBuildEvent(t *testing.T) {
 						},
 						Timeout:        DurationMinutes(60 * time.Minute),
 						BuildComplete:  true,
+						BuildNumber:    55,
 						Initiator:      "MyCodeBuildDemoUser",
 						BuildStartTime: CodeBuildTime(time.Date(2017, 9, 1, 16, 12, 29, 0, time.UTC)),
 						Source: CodeBuildSource{

--- a/events/testdata/codebuild-phase-change.json
+++ b/events/testdata/codebuild-phase-change.json
@@ -29,6 +29,7 @@
             },
             "timeout-in-minutes": 60.0,
             "build-complete": true,
+            "build-number": 55.0,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
             "source": {

--- a/events/testdata/codebuild-state-change.json
+++ b/events/testdata/codebuild-state-change.json
@@ -34,7 +34,7 @@
             },
             "timeout-in-minutes": 60.0,
             "build-complete": true,
-            "build-number": 55.0,
+            "build-number": 55,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
             "source": {

--- a/events/testdata/codebuild-state-change.json
+++ b/events/testdata/codebuild-state-change.json
@@ -34,6 +34,7 @@
             },
             "timeout-in-minutes": 60.0,
             "build-complete": true,
+            "build-number": 55.0,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
             "source": {

--- a/events/testdata/codebuild-state-change.json
+++ b/events/testdata/codebuild-state-change.json
@@ -34,7 +34,7 @@
             },
             "timeout-in-minutes": 60.0,
             "build-complete": true,
-            "build-number": 55,
+            "build-number": 55.0,
             "initiator": "MyCodeBuildDemoUser",
             "build-start-time": "Sep 1, 2017 4:12:29 PM",
             "source": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-go/issues/413

*Description of changes:*
Add missing BuildNumber to CodeBuildEventAdditionalInformation struct, and update tests.
SUCCEEDED, FAILED, STOPPED events do have the piece of info, not presented in IN_PROGRESS event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
