### PR TITLE
feat<events.cognito>: add support for custom email sender

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -266,3 +266,24 @@ type CognitoEventUserPoolsCustomMessageResponse struct {
 	EmailMessage string `json:"emailMessage"`
 	EmailSubject string `json:"emailSubject"`
 }
+
+// CognitoEventUserPoolsCustomEmailSender is sent by AWS Cognito User Pools before each mail to send.
+type CognitoEventUserPoolsCustomEmailSender struct {
+	CognitoEventUserPoolsHeader
+	Request  CognitoEventUserPoolsCustomMessageRequest  `json:"request"`
+	Response CognitoEventUserPoolsCustomMessageResponse `json:"response"`
+}
+
+// CognitoEventUserPoolsCustomEmailSenderRequest contains the request portion of a CustomEmailSender event
+type CognitoEventUserPoolsCustomEmailSenderRequest struct {
+	UserAttributes map[string]interface{} `json:"userAttributes"`
+	Code           string                 `json:"code"`
+	ClientMetadata map[string]string      `json:"clientMetadata"`
+	Type           string                 `json:"type"`
+}
+
+// CognitoEventUserPoolsCustomEmailSenderResponse contains the response portion of a CustomEmailSender event
+type CognitoEventUserPoolsCustomEmailSenderResponse struct {
+	EmailMessage string `json:"emailMessage"`
+	EmailSubject string `json:"emailSubject"`
+}

--- a/events/cognito.go
+++ b/events/cognito.go
@@ -270,8 +270,8 @@ type CognitoEventUserPoolsCustomMessageResponse struct {
 // CognitoEventUserPoolsCustomEmailSender is sent by AWS Cognito User Pools before each mail to send.
 type CognitoEventUserPoolsCustomEmailSender struct {
 	CognitoEventUserPoolsHeader
-	Request  CognitoEventUserPoolsCustomMessageRequest  `json:"request"`
-	Response CognitoEventUserPoolsCustomMessageResponse `json:"response"`
+	Request  CognitoEventUserPoolsCustomEmailSenderRequest  `json:"request"`
+	Response CognitoEventUserPoolsCustomEmailSenderResponse `json:"response"`
 }
 
 // CognitoEventUserPoolsCustomEmailSenderRequest contains the request portion of a CustomEmailSender event

--- a/events/cognito_test.go
+++ b/events/cognito_test.go
@@ -240,3 +240,29 @@ func TestCognitoEventUserPoolsCustomMessageMarshaling(t *testing.T) {
 func TestCognitoUserPoolsCustomMessageMarshalingMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, CognitoEventUserPoolsCustomMessage{})
 }
+
+func TestCognitoEventUserPoolsCustomEmailSenderMarshaling(t *testing.T) {
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-customemailsender.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into CognitoEvent
+	var inputEvent CognitoEventUserPoolsCustomEmailSender
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func TestCognitoUserPoolsCustomEmailSenderMarshalingMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, CognitoEventUserPoolsCustomEmailSender{})
+}

--- a/events/testdata/cognito-event-userpools-customemailsender.json
+++ b/events/testdata/cognito-event-userpools-customemailsender.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "triggerSource": "CustomEmailSender_SignUp/CustomEmailSender_ResendCode/CustomEmailSender_ForgotPassword/CustomEmailSender_UpdateUserAttribute/CustomEmailSender_VerifyUserAttribute/CustomEmailSender_AdminCreateUser",
+  "region": "<region>",
+  "userPoolId": "<userPoolId>",
+  "userName": "<userName>",
+  "callerContext": {
+      "awsSdkVersion": "<calling aws sdk with version>",
+      "clientId": "<apps client id>"
+  },
+  "request": {
+      "userAttributes": {
+          "phone_number_verified": true,
+          "email_verified": false
+       },
+      "code": "example code",
+      "usernameParameter": "{username}",
+      "clientMetadata": {
+        "exampleMetadataKey": "example metadata value"
+      }
+  },
+  "response": {
+      "emailMessage": "<custom message to be sent in the email>",
+      "emailSubject": "<custom email subject>"
+  }
+}

--- a/events/testdata/cognito-event-userpools-customemailsender.json
+++ b/events/testdata/cognito-event-userpools-customemailsender.json
@@ -14,10 +14,10 @@
           "email_verified": false
        },
       "code": "example code",
-      "usernameParameter": "{username}",
       "clientMetadata": {
         "exampleMetadataKey": "example metadata value"
-      }
+      },
+    "type": "example type"
   },
   "response": {
       "emailMessage": "<custom message to be sent in the email>",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-go/issues/370

*Description of changes:*
added new event struct for support of customEmailSender messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
