### PR TITLE
Omit authentication field in APIGatewayV2HTTPRequestContext

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -76,7 +76,7 @@ type APIGatewayV2HTTPRequestContext struct {
 	Time           string                                               `json:"time"`
 	TimeEpoch      int64                                                `json:"timeEpoch"`
 	HTTP           APIGatewayV2HTTPRequestContextHTTPDescription        `json:"http"`
-	Authentication APIGatewayV2HTTPRequestContextAuthentication         `json:"authentication"`
+	Authentication APIGatewayV2HTTPRequestContextAuthentication         `json:"authentication,omitempty"`
 }
 
 // APIGatewayV2HTTPRequestContextAuthorizerDescription contains authorizer information for the request context.


### PR DESCRIPTION
This field is not in the payload for public APIs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
