### PR TITLE
Omit CodePipelineEventDetailType when it's missing in the payload

### DIFF
--- a/events/codepipeline_cloudwatch.go
+++ b/events/codepipeline_cloudwatch.go
@@ -92,7 +92,7 @@ type CodePipelineEventDetail struct {
 
 	Region string `json:"region"`
 
-	Type CodePipelineEventDetailType `json:"type"`
+	Type CodePipelineEventDetailType `json:"type,omitempty"`
 }
 
 type CodePipelineEventDetailType struct {


### PR DESCRIPTION
The examples in testdata don't include this field, so I'm guessing it's optional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
