### PR TITLE
Omit empty fields in CodeBuildPhase

### DIFF
--- a/events/codebuild.go
+++ b/events/codebuild.go
@@ -157,17 +157,17 @@ type CodeBuildLogs struct {
 
 // CodeBuildPhase represents the phase of a build and its details
 type CodeBuildPhase struct {
-	PhaseContext []interface{} `json:"phase-context"`
+	PhaseContext []interface{} `json:"phase-context,omitempty"`
 
 	StartTime CodeBuildTime `json:"start-time"`
 
-	EndTime CodeBuildTime `json:"end-time"`
+	EndTime CodeBuildTime `json:"end-time,omitempty"`
 
-	Duration DurationSeconds `json:"duration-in-seconds"`
+	Duration DurationSeconds `json:"duration-in-seconds,omitempty"`
 
 	PhaseType CodeBuildPhaseType `json:"phase-type"`
 
-	PhaseStatus CodeBuildPhaseStatus `json:"phase-status"`
+	PhaseStatus CodeBuildPhaseStatus `json:"phase-status,omitempty"`
 }
 
 // CodeBuildTime represents the time of the build


### PR DESCRIPTION
The last element of a list of phases sent by code build only contains `start-time` and `phase-type`, the rest of the fields are missing.

I don't know why it only sends those two fields, but I've confirmed this with the CodeBuild folks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
