### PR TITLE
Feature/Add path field in request context struct

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -40,6 +40,7 @@ type APIGatewayProxyRequestContext struct {
 	Protocol         string                    `json:"protocol"`
 	Identity         APIGatewayRequestIdentity `json:"identity"`
 	ResourcePath     string                    `json:"resourcePath"`
+	Path             string                    `json:"path"`
 	Authorizer       map[string]interface{}    `json:"authorizer"`
 	HTTPMethod       string                    `json:"httpMethod"`
 	RequestTime      string                    `json:"requestTime"`

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -59,6 +59,7 @@
 	"requestContext": {
 		"accountId": "12345678912",
 		"resourceId": "roq9wj",
+		"path": "/hello/world",
 		"stage": "testStage",
 		"domainName": "gy415nuibc.execute-api.us-east-2.amazonaws.com",
 		"domainPrefix": "y0ne18dixk",

--- a/events/testdata/apigw-restapi-openapi-request.json
+++ b/events/testdata/apigw-restapi-openapi-request.json
@@ -59,6 +59,7 @@
   "requestContext": {
     "accountId": "12345678912",
     "resourceId": "roq9wj",
+    "path": "/hello/world",
     "operationName": "HelloWorld",
     "stage": "testStage",
     "domainName": "gy415nuibc.execute-api.us-east-2.amazonaws.com",


### PR DESCRIPTION
*Issue #, if available:* no created issue

*Description of changes:* add path field in APIGatewayProxyRequestContext

According to the doc seen [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format), the lambda function input coming from API Gateway has the "path" field inside "requestContext".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
