### PR TITLE
add Lambda Function URLs sample

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -56,6 +56,8 @@ This package provides input types for Lambda functions that process AWS events.
 
 [Kinesis Firehose Events](README_KinesisFirehose.md)
 
+[Lambda Events](README_Lambda.md)
+
 [Lex Events](README_Lex.md)
 
 [S3 Events](README_S3.md)

--- a/events/README_Lambda.md
+++ b/events/README_Lambda.md
@@ -1,6 +1,6 @@
 # Overview
 
-Lambda events consist of a request that was routed to a Lambda function by Lambda Function URLs feature. When this happens, Lambda expects the result of the function to be the response that Lambda should respond with.
+Lambda events consist of a request that was routed to a Lambda function by the Lambda Function URLs feature. When this happens, Lambda expects the result of the function to be the response that Lambda should respond with.
 
 # Sample Function
 

--- a/events/README_Lambda.md
+++ b/events/README_Lambda.md
@@ -1,0 +1,35 @@
+# Overview
+
+Lambda events consist of a request that was routed to a Lambda function by Lambda Function URLs feature. When this happens, Lambda expects the result of the function to be the response that Lambda should respond with.
+
+# Sample Function
+
+The following is a sample class and Lambda function that receives Lambda Function URLs event record data as an input, writes some of the record data to CloudWatch Logs, and responds with a 200 status and the same body as the request. (Note that anything written to stdout or stderr will be logged as CloudWatch Logs events.)
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+func handleRequest(ctx context.Context, request events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+	fmt.Printf("Processing request data for request %s.\n", request.RequestContext.RequestID)
+	fmt.Printf("Body size = %d.\n", len(request.Body))
+
+	fmt.Println("Headers:")
+	for key, value := range request.Headers {
+		fmt.Printf("    %s: %s\n", key, value)
+	}
+
+	return events.LambdaFunctionURLResponse{Body: request.Body, StatusCode: 200}, nil
+}
+
+func main() {
+	lambda.Start(handleRequest)
+}
+```


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Added sample using Lambda Function URLs feature

*Motivation:* Most of the contents are similar to those of API Gateway, but it is better to have them than not to have them.

*Ref:* 
- [Announcing AWS Lambda Function URLs: Built-in HTTPS Endpoints for Single-Function Microservices | AWS News Blog](https://aws.amazon.com/jp/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/)
- [Lambda function URLs - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
