### PR TITLE
Add capability to define optional handler behavior

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -28,6 +28,14 @@ type handlerOptions struct {
 type Option func(*handlerOptions)
 
 // WithContext is a HandlerOption that sets the base context for all invocations of the handler.
+//
+// Usage:
+//  lambda.StartWithOptions(
+//   	func (ctx context.Context) (string, error) {
+//   		return ctx.Value("foo"), nil
+//   	},
+//   	lambda.WithContext(context.WithValue(context.Background(), "foo", "bar"))
+//  )
 func WithContext(ctx context.Context) Option {
 	return Option(func(h *handlerOptions) {
 		h.baseContext = ctx
@@ -35,6 +43,14 @@ func WithContext(ctx context.Context) Option {
 }
 
 // WithSetEscapeHTML sets the SetEscapeHTML argument on the underlying json encoder
+//
+// Usage:
+//  lambda.StartWithOptions(
+//  	func () (string, error) {
+//  		return "<html><body>hello!></body></html>", nil
+//  	},
+//  	lambda.WithSetEscapeHTML(true),
+//  )
 func WithSetEscapeHTML(escapeHTML bool) Option {
 	return Option(func(h *handlerOptions) {
 		h.jsonResponseEscapeHTML = escapeHTML
@@ -42,6 +58,14 @@ func WithSetEscapeHTML(escapeHTML bool) Option {
 }
 
 // WithSetIndent sets the SetIndent argument on the underling json encoder
+//
+// Usage:
+//  lambda.StartWithOptions(
+//  	func (event any) (any, error) {
+//  		return event, nil
+//  	},
+//  	lambda.WithSetIndent(">"," "),
+//  )
 func WithSetIndent(prefix, indent string) Option {
 	return Option(func(h *handlerOptions) {
 		h.jsonResponseIndentPrefix = prefix

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -3,8 +3,10 @@
 package lambda
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -15,29 +17,36 @@ type Handler interface {
 	Invoke(ctx context.Context, payload []byte) ([]byte, error)
 }
 
-// lambdaHandler is the generic function type
-type lambdaHandler func(context.Context, []byte) (interface{}, error)
-
-// Invoke calls the handler, and serializes the response.
-// If the underlying handler returned an error, or an error occurs during serialization, error is returned.
-func (handler lambdaHandler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
-	response, err := handler(ctx, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	responseBytes, err := json.Marshal(response)
-	if err != nil {
-		return nil, err
-	}
-
-	return responseBytes, nil
+type handlerOptions struct {
+	Handler
+	baseContext context.Context
+	escapeHTML  bool
+	prefix      string
+	indent      string
 }
 
-func errorHandler(e error) lambdaHandler {
-	return func(ctx context.Context, event []byte) (interface{}, error) {
-		return nil, e
-	}
+type Option func(*handlerOptions)
+
+// WithContext is a HandlerOption that sets the base context for all invocations of the handler.
+func WithContext(ctx context.Context) Option {
+	return Option(func(h *handlerOptions) {
+		h.baseContext = ctx
+	})
+}
+
+// WithSetEscapeHTML sets the SetEscapeHTML argument on the underlying json encoder
+func WithSetEscapeHTML(escapeHTML bool) Option {
+	return Option(func(h *handlerOptions) {
+		h.escapeHTML = escapeHTML
+	})
+}
+
+// WithSetIndent sets the SetIndent argument on the underling json encoder
+func WithSetIndent(prefix, indent string) Option {
+	return Option(func(h *handlerOptions) {
+		h.prefix = prefix
+		h.indent = indent
+	})
 }
 
 func validateArguments(handler reflect.Type) (bool, error) {
@@ -77,13 +86,59 @@ func validateReturns(handler reflect.Type) error {
 
 // NewHandler creates a base lambda handler from the given handler function. The
 // returned Handler performs JSON serialization and deserialization, and
-// delegates to the input handler function.  The handler function parameter must
-// satisfy the rules documented by Start.  If handlerFunc is not a valid
+// delegates to the input handler function. The handler function parameter must
+// satisfy the rules documented by Start. If handlerFunc is not a valid
 // handler, the returned Handler simply reports the validation error.
 func NewHandler(handlerFunc interface{}) Handler {
-	if handlerFunc == nil {
-		return errorHandler(fmt.Errorf("handler is nil"))
+	return NewHandlerWithOptions(handlerFunc)
+}
+
+// NewHandlerWithOptions creates a base lambda handler from the given handler function. The
+// returned Handler performs JSON serialization and deserialization, and
+// delegates to the input handler function. The handler function parameter must
+// satisfy the rules documented by Start. If handlerFunc is not a valid
+// handler, the returned Handler simply reports the validation error.
+func NewHandlerWithOptions(handlerFunc interface{}, options ...Option) Handler {
+	return newHandler(handlerFunc, options...)
+}
+
+func newHandler(handlerFunc interface{}, options ...Option) *handlerOptions {
+	if h, ok := handlerFunc.(*handlerOptions); ok {
+		return h
 	}
+	h := &handlerOptions{
+		baseContext: context.Background(),
+		escapeHTML:  false,
+		prefix:      "",
+		indent:      "",
+	}
+	for _, option := range options {
+		option(h)
+	}
+	h.Handler = reflectHandler(handlerFunc, h)
+	return h
+}
+
+type bytesHandlerFunc func(context.Context, []byte) ([]byte, error)
+
+func (h bytesHandlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
+	return h(ctx, payload)
+}
+func errorHandler(err error) Handler {
+	return bytesHandlerFunc(func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, err
+	})
+}
+
+func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
+	if handlerFunc == nil {
+		return errorHandler(errors.New("handler is nil"))
+	}
+
+	if handler, ok := handlerFunc.(Handler); ok {
+		return handler
+	}
+
 	handler := reflect.ValueOf(handlerFunc)
 	handlerType := reflect.TypeOf(handlerFunc)
 	if handlerType.Kind() != reflect.Func {
@@ -99,7 +154,13 @@ func NewHandler(handlerFunc interface{}) Handler {
 		return errorHandler(err)
 	}
 
-	return lambdaHandler(func(ctx context.Context, payload []byte) (interface{}, error) {
+	return bytesHandlerFunc(func(ctx context.Context, payload []byte) ([]byte, error) {
+		in := bytes.NewBuffer(payload)
+		out := bytes.NewBuffer(nil)
+		decoder := json.NewDecoder(in)
+		encoder := json.NewEncoder(out)
+		encoder.SetEscapeHTML(h.escapeHTML)
+		encoder.SetIndent(h.prefix, h.indent)
 
 		trace := handlertrace.FromContext(ctx)
 
@@ -111,8 +172,7 @@ func NewHandler(handlerFunc interface{}) Handler {
 		if (handlerType.NumIn() == 1 && !takesContext) || handlerType.NumIn() == 2 {
 			eventType := handlerType.In(handlerType.NumIn() - 1)
 			event := reflect.New(eventType)
-
-			if err := json.Unmarshal(payload, event.Interface()); err != nil {
+			if err := decoder.Decode(event.Interface()); err != nil {
 				return nil, err
 			}
 			if nil != trace.RequestEvent {
@@ -123,22 +183,30 @@ func NewHandler(handlerFunc interface{}) Handler {
 
 		response := handler.Call(args)
 
-		// convert return values into (interface{}, error)
-		var err error
+		// return the error, if any
 		if len(response) > 0 {
-			if errVal, ok := response[len(response)-1].Interface().(error); ok {
-				err = errVal
+			if errVal, ok := response[len(response)-1].Interface().(error); ok && errVal != nil {
+				return nil, errVal
 			}
 		}
+		// set the response value, if any
 		var val interface{}
 		if len(response) > 1 {
 			val = response[0].Interface()
-
 			if nil != trace.ResponseEvent {
 				trace.ResponseEvent(ctx, val)
 			}
 		}
+		if err := encoder.Encode(val); err != nil {
+			return nil, err
+		}
 
-		return val, err
+		responseBytes := out.Bytes()
+		// back-compat, strip the encoder's trailing newline unless WithSetIndent was used
+		if h.indent == "" && h.prefix == "" {
+			return responseBytes[:len(responseBytes)-1], nil
+		}
+
+		return responseBytes, nil
 	})
 }

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -22,7 +22,7 @@ type handlerOptions struct {
 	baseContext              context.Context
 	jsonResponseEscapeHTML   bool
 	jsonResponseIndentPrefix string
-	jsonResponseIndentWidth  string
+	jsonResponseIndentValue  string
 }
 
 type Option func(*handlerOptions)
@@ -69,7 +69,7 @@ func WithSetEscapeHTML(escapeHTML bool) Option {
 func WithSetIndent(prefix, indent string) Option {
 	return Option(func(h *handlerOptions) {
 		h.jsonResponseIndentPrefix = prefix
-		h.jsonResponseIndentWidth = indent
+		h.jsonResponseIndentValue = indent
 	})
 }
 
@@ -134,7 +134,7 @@ func newHandler(handlerFunc interface{}, options ...Option) *handlerOptions {
 		baseContext:              context.Background(),
 		jsonResponseEscapeHTML:   false,
 		jsonResponseIndentPrefix: "",
-		jsonResponseIndentWidth:  "",
+		jsonResponseIndentValue:  "",
 	}
 	for _, option := range options {
 		option(h)
@@ -184,7 +184,7 @@ func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
 		decoder := json.NewDecoder(in)
 		encoder := json.NewEncoder(out)
 		encoder.SetEscapeHTML(h.jsonResponseEscapeHTML)
-		encoder.SetIndent(h.jsonResponseIndentPrefix, h.jsonResponseIndentWidth)
+		encoder.SetIndent(h.jsonResponseIndentPrefix, h.jsonResponseIndentValue)
 
 		trace := handlertrace.FromContext(ctx)
 
@@ -227,7 +227,7 @@ func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
 
 		responseBytes := out.Bytes()
 		// back-compat, strip the encoder's trailing newline unless WithSetIndent was used
-		if h.jsonResponseIndentWidth == "" && h.jsonResponseIndentPrefix == "" {
+		if h.jsonResponseIndentValue == "" && h.jsonResponseIndentPrefix == "" {
 			return responseBytes[:len(responseBytes)-1], nil
 		}
 

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -3,7 +3,6 @@
 package lambda
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -19,9 +18,9 @@ const (
 )
 
 // startRuntimeAPILoop will return an error if handling a particular invoke resulted in a non-recoverable error
-func startRuntimeAPILoop(ctx context.Context, api string, handler Handler) error {
+func startRuntimeAPILoop(api string, handler Handler) error {
 	client := newRuntimeAPIClient(api)
-	function := NewFunction(handler).withContext(ctx)
+	function := NewFunction(handler)
 	for {
 		invoke, err := client.next()
 		if err != nil {

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -26,7 +26,7 @@ func TestFatalErrors(t *testing.T) {
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedErrorMessage := "calling the handler function resulted in a panic, the process should exit"
-	assert.EqualError(t, startRuntimeAPILoop(context.Background(), endpoint, handler), expectedErrorMessage)
+	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedErrorMessage)
 	assert.Equal(t, 1, record.nGets)
 	assert.Equal(t, 1, record.nGets)
 }
@@ -47,7 +47,7 @@ func TestRuntimeAPILoop(t *testing.T) {
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedError := fmt.Sprintf("failed to GET http://%s/2018-06-01/runtime/invocation/next: got unexpected status code: 410", endpoint)
-	assert.EqualError(t, startRuntimeAPILoop(context.Background(), endpoint, handler), expectedError)
+	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedError)
 	assert.Equal(t, nInvokes+1, record.nGets)
 	assert.Equal(t, nInvokes, record.nPosts)
 }
@@ -63,7 +63,7 @@ func TestRuntimeAPIContextPlumbing(t *testing.T) {
 
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedError := fmt.Sprintf("failed to GET http://%s/2018-06-01/runtime/invocation/next: got unexpected status code: 410", endpoint)
-	assert.EqualError(t, startRuntimeAPILoop(context.Background(), endpoint, handler), expectedError)
+	assert.EqualError(t, startRuntimeAPILoop(endpoint, handler), expectedError)
 
 	expected := `
 	{
@@ -101,7 +101,7 @@ func TestReadPayload(t *testing.T) {
 		return string(reversed), nil
 	})
 	endpoint := strings.Split(ts.URL, "://")[1]
-	_ = startRuntimeAPILoop(context.Background(), endpoint, handler)
+	_ = startRuntimeAPILoop(endpoint, handler)
 	assert.Equal(t, `"socat gnivarc ma I"`, string(record.responses[0]))
 
 }

--- a/lambda/rpc.go
+++ b/lambda/rpc.go
@@ -6,7 +6,6 @@
 package lambda
 
 import (
-	"context"
 	"errors"
 	"log"
 	"net"
@@ -20,12 +19,12 @@ func init() {
 	rpcStartFunction.f = startFunctionRPC
 }
 
-func startFunctionRPC(ctx context.Context, port string, handler Handler) error {
+func startFunctionRPC(port string, handler Handler) error {
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = rpc.Register(NewFunction(handler).withContext(ctx))
+	err = rpc.Register(NewFunction(handler))
 	if err != nil {
 		log.Fatal("failed to register handler function")
 	}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/177
https://github.com/aws/aws-lambda-go/pull/178#discussion_r266617767

*Description of changes:*

* add Option WithSetEscapeHTML to set this same named option on the underlying json encoder
* refactor implementations of ***WithContext functions to use the Option WithContext
* mark a bunch of not useful related stuff as deprecated so that they are hidden in the godocs

This adds an options pattern for allowing a function author to pick from one or more customizations to the default runtime behavior. The pattern can later be followed to implement other requests for changes to the default runtime behavior. Example feature request:  https://github.com/aws/aws-lambda-go/issues/433


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
