### PR TITLE
Add ExtendedRequestId to APIGatewayProxyRequestContext

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -30,22 +30,23 @@ type APIGatewayProxyResponse struct {
 // APIGatewayProxyRequestContext contains the information to identify the AWS account and resources invoking the
 // Lambda function. It also includes Cognito identity information for the caller.
 type APIGatewayProxyRequestContext struct {
-	AccountID        string                    `json:"accountId"`
-	ResourceID       string                    `json:"resourceId"`
-	OperationName    string                    `json:"operationName,omitempty"`
-	Stage            string                    `json:"stage"`
-	DomainName       string                    `json:"domainName"`
-	DomainPrefix     string                    `json:"domainPrefix"`
-	RequestID        string                    `json:"requestId"`
-	Protocol         string                    `json:"protocol"`
-	Identity         APIGatewayRequestIdentity `json:"identity"`
-	ResourcePath     string                    `json:"resourcePath"`
-	Path             string                    `json:"path"`
-	Authorizer       map[string]interface{}    `json:"authorizer"`
-	HTTPMethod       string                    `json:"httpMethod"`
-	RequestTime      string                    `json:"requestTime"`
-	RequestTimeEpoch int64                     `json:"requestTimeEpoch"`
-	APIID            string                    `json:"apiId"` // The API Gateway rest API Id
+	AccountID         string                    `json:"accountId"`
+	ResourceID        string                    `json:"resourceId"`
+	OperationName     string                    `json:"operationName,omitempty"`
+	Stage             string                    `json:"stage"`
+	DomainName        string                    `json:"domainName"`
+	DomainPrefix      string                    `json:"domainPrefix"`
+	RequestID         string                    `json:"requestId"`
+	ExtendedRequestID string                    `json:"extendedRequestId"`
+	Protocol          string                    `json:"protocol"`
+	Identity          APIGatewayRequestIdentity `json:"identity"`
+	ResourcePath      string                    `json:"resourcePath"`
+	Path              string                    `json:"path"`
+	Authorizer        map[string]interface{}    `json:"authorizer"`
+	HTTPMethod        string                    `json:"httpMethod"`
+	RequestTime       string                    `json:"requestTime"`
+	RequestTimeEpoch  int64                     `json:"requestTimeEpoch"`
+	APIID             string                    `json:"apiId"` // The API Gateway rest API Id
 }
 
 // APIGatewayV2HTTPRequest contains data coming from the new HTTP API Gateway

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -64,6 +64,7 @@
 		"domainName": "gy415nuibc.execute-api.us-east-2.amazonaws.com",
 		"domainPrefix": "y0ne18dixk",
 		"requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
+		"extendedRequestId": "TWegAcC4EowCHnA=",
 		"protocol": "HTTP/1.1",
 		"identity": {
 			"cognitoIdentityPoolId": "theCognitoIdentityPoolId",

--- a/events/testdata/apigw-restapi-openapi-request.json
+++ b/events/testdata/apigw-restapi-openapi-request.json
@@ -65,6 +65,7 @@
     "domainName": "gy415nuibc.execute-api.us-east-2.amazonaws.com",
     "domainPrefix": "y0ne18dixk",
     "requestId": "deef4878-7910-11e6-8f14-25afc3e9ae33",
+    "extendedRequestId": "TWegAcC4EowCHnA=",
     "protocol": "HTTP/1.1",
     "identity": {
       "cognitoIdentityPoolId": "theCognitoIdentityPoolId",


### PR DESCRIPTION
It exists on APIGatewayWebsocketProxyRequestContext but not ExtendedRequestId.
It is however present on non-websocket requests and should be accessible by consumers of this package.

* REST https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
* HTTP https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging-variables.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
