### PR TITLE
Revert #408 and update alb response annotation per #408's original intent

### DIFF
--- a/events/alb.go
+++ b/events/alb.go
@@ -29,6 +29,6 @@ type ALBTargetGroupResponse struct {
 	StatusDescription string              `json:"statusDescription"`
 	Headers           map[string]string   `json:"headers"`
 	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
-	Body              string              `json:"body"`
+	Body              string              `json:"body,omitempty"`
 	IsBase64Encoded   bool                `json:"isBase64Encoded"`
 }

--- a/events/alb.go
+++ b/events/alb.go
@@ -10,7 +10,7 @@ type ALBTargetGroupRequest struct {
 	MultiValueHeaders               map[string][]string          `json:"multiValueHeaders,omitempty"`
 	RequestContext                  ALBTargetGroupRequestContext `json:"requestContext"`
 	IsBase64Encoded                 bool                         `json:"isBase64Encoded"`
-	Body                            string                       `json:"body,omitempty"`
+	Body                            string                       `json:"body"`
 }
 
 // ALBTargetGroupRequestContext contains the information to identify the load balancer invoking the lambda

--- a/events/testdata/alb-lambda-target-request-headers-only.json
+++ b/events/testdata/alb-lambda-target-request-headers-only.json
@@ -21,5 +21,6 @@
     "x-imforwards": "20",
     "x-myheader": "123"
   },
+  "body": "",
   "isBase64Encoded": false
 }

--- a/events/testdata/alb-lambda-target-request-multivalue-headers.json
+++ b/events/testdata/alb-lambda-target-request-multivalue-headers.json
@@ -43,6 +43,6 @@
       "123"
     ]
   },
-  "body": "Some text",
+  "body": "",
   "isBase64Encoded": false
 }


### PR DESCRIPTION
*Issue #, if available:*

see: https://github.com/aws/aws-lambda-go/issues/438#issue-1196408756

*Description of changes:*

#408 intended to update the response type, but modified the request type instead. This has no change in actual behavior, but I felt it was confusing to leave it as-is. So submitted this PR as a re-do



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
