### PR TITLE
dynamodb: add alternative to Integer conversion helper, Int64, that does not silently cast float values

### DIFF
--- a/events/attributevalue.go
+++ b/events/attributevalue.go
@@ -68,6 +68,15 @@ func (av DynamoDBAttributeValue) Number() string {
 	return av.value.(string)
 }
 
+// Int64 provides access to an attribute of type Number.
+// DynamoDB sends the values as strings. For convenience this method
+// provides conversion to int.
+// Method panics if the attribute is not of type Number.
+func (av DynamoDBAttributeValue) Int64() (int64, error) {
+	number := av.Number()
+	return strconv.ParseInt(number, 10, 64)
+}
+
 // Integer provides access to an attribute of type Number.
 // DynamoDB sends the values as strings. For convenience this method
 // provides conversion to int. If the value cannot be represented by
@@ -76,7 +85,7 @@ func (av DynamoDBAttributeValue) Number() string {
 // Method panics if the attribute is not of type Number.
 func (av DynamoDBAttributeValue) Integer() (int64, error) {
 	number := av.Number()
-	value, err := strconv.ParseInt(number, 10, 64)
+	value, err := av.Int64()
 	if err == nil {
 		return value, nil
 	}


### PR DESCRIPTION

*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/454

*Description of changes:*

Same as Integer(), but without the "convenience" of falling back to float parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
