### PR TITLE
fix godoc typo in example for WithEnableSIGTERM

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -81,7 +81,7 @@ func WithSetIndent(prefix, indent string) Option {
 //
 // Usage:
 //  lambda.StartWithOptions(
-//      func (event any) (any error) {
+//      func (event any) (any, error) {
 //  		return event, nil
 //  	},
 //  	lambda.WithEnableSIGTERM(func() {


### PR DESCRIPTION

*Description of changes:*

noticed a missing comma in the returns, oops!  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
