### PR TITLE
use `go install` to install `build-lambda-zip`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Windows developers may have trouble producing a zip file that marks the binary a
 
 Get the tool
 ``` shell
-set GO111MODULE=on
-go.exe get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip
+go.exe install github.com/aws/aws-lambda-go/cmd/build-lambda-zip@latest
 ```
 
 Use the tool from your `GOPATH`. If you have a default installation of Go, the tool will be in `%USERPROFILE%\Go\bin`. 


### PR DESCRIPTION
*Issue #, if available:*

fixes https://github.com/aws/aws-lambda-go/issues/463

*Description of changes:*

go 1.18 removed the ability to use `go get` to install binaries.
we should use `go install` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
