### PR TITLE
Lambda direct resolver event type

### DIFF
--- a/events/appsync.go
+++ b/events/appsync.go
@@ -66,7 +66,7 @@ type AppSyncLambdaAuthorizerResponse struct {
 	TTLOverride     *int                   `json:"ttlOverride,omitempty"`
 }
 
-//AppSyncDirectLambdaResolverRequest represents a direct lambda resolver request event
+// AppSyncDirectLambdaResolverRequest represents a direct lambda resolver request event
 type AppSyncDirectLambdaResolverRequest struct {
 	Arguments map[string]interface{} `json:"arguments"`
 	Identity  map[string]interface{} `json:"identity"`

--- a/events/appsync.go
+++ b/events/appsync.go
@@ -65,3 +65,49 @@ type AppSyncLambdaAuthorizerResponse struct {
 	DeniedFields    []string               `json:"deniedFields,omitempty"`
 	TTLOverride     *int                   `json:"ttlOverride,omitempty"`
 }
+
+//Represents a direct lambda resolver request event
+type AppsyncDirectLambdaResolverRequest struct {
+	Arguments map[string]interface{} `json:"arguments"`
+	Identity  map[string]interface{} `json:"identity"`
+	Info      struct {
+		FieldName           string   `json:"fieldName"`
+		ParentTypeName      string   `json:"parentTypeName"`
+		SelectionSetGraphQL string   `json:"selectionSetGraphQL"`
+		SelectionSetList    []string `json:"selectionSetList"`
+	}
+	Prev    string `json:"prev"`
+	Request struct {
+		Headers struct {
+			Accept                    string `json:"accept"`
+			Authorization             string `json:"authorization"`
+			AcceptEncoding            string `json:"accept-encoding"`
+			AcceptLanguage            string `json:"accept-language"`
+			CloudfrontForwardedProto  string `json:"cloudfront-forwarded-proto"`
+			CloudfrontIsDesktopViewer string `json:"cloudfront-is-desktop-viewer"`
+			CloudfrontIsMobileViewer  string `json:"cloudfront-is-mobile-viewer"`
+			CloudfrontIsSmarttvViewer string `json:"cloudfront-is-smarttv-viewer"`
+			CloudfrontViewerCountry   string `json:"cloudfront-viewer-country"`
+			CloudfrontIsTabletViewer  string `json:"cloudfront-is-tablet-viewer"`
+			ContentLength             string `json:"content-length"`
+			ContentType               string `json:"content-type"`
+			Host                      string `json:"host"`
+			Hrigin                    string `json:"origin"`
+			Referer                   string `json:"Referer"`
+			SecFetchDest              string `json:"sec-fetch-dest"`
+			SecFetchMode              string `json:"sec-fetch-mode"`
+			SecFetchSite              string `json:"sec-fetch-site"`
+			UserAgent                 string `json:"user-agent"`
+			Via                       string `json:"via"`
+			XAmzCfID                  string `json:"x-amz-cf-id"`
+			XAmzUserAgent             string `json:"x-amz-user-agent"`
+			XAmznTraceID              string `json:"x-amzn-trace-id"`
+			XApiKey                   string `json:"x-api-key"`
+			XForwardedFor             string `json:"x-forwarded-for"`
+			XForwardedPort            string `json:"x-forwarded-port"`
+			XForwardedProto           string `json:"x-forwarded-proto"`
+		}
+	}
+	Source map[string]interface{} `json:"source"`
+	Stash  map[string]string      `json:"stash"`
+}

--- a/events/appsync.go
+++ b/events/appsync.go
@@ -66,7 +66,7 @@ type AppSyncLambdaAuthorizerResponse struct {
 	TTLOverride     *int                   `json:"ttlOverride,omitempty"`
 }
 
-//Represents a direct lambda resolver request event
+//AppSyncDirectLambdaResolverRequest represents a direct lambda resolver request event
 type AppSyncDirectLambdaResolverRequest struct {
 	Arguments map[string]interface{} `json:"arguments"`
 	Identity  map[string]interface{} `json:"identity"`

--- a/events/appsync.go
+++ b/events/appsync.go
@@ -67,7 +67,7 @@ type AppSyncLambdaAuthorizerResponse struct {
 }
 
 //Represents a direct lambda resolver request event
-type AppsyncDirectLambdaResolverRequest struct {
+type AppSyncDirectLambdaResolverRequest struct {
 	Arguments map[string]interface{} `json:"arguments"`
 	Identity  map[string]interface{} `json:"identity"`
 	Info      struct {

--- a/events/appsync_test.go
+++ b/events/appsync_test.go
@@ -89,6 +89,25 @@ func TestAppSyncLambdaAuthorizerResponseMarshalling(t *testing.T) {
 	assert.JSONEq(t, string(inputJSON), string(outputJSON))
 }
 
+func TestAppSyncDirectLambdaResolverRequestMarshalling(t *testing.T) {
+	inputJSON, err := ioutil.ReadFile("./testdata/appsync-direct-resolver-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	var inputEvent AppSyncDirectLambdaResolverRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
 func TestAppSyncLambdaAuthorizerResponseMalformedJson(t *testing.T) {
 	test.TestMalformedJson(t, AppSyncLambdaAuthorizerResponse{})
 }

--- a/events/testdata/appsync-direct-resolver-request.json
+++ b/events/testdata/appsync-direct-resolver-request.json
@@ -1,0 +1,53 @@
+{
+    "arguments": {
+        "exampleArgument": "exampleArgumentValue"
+    },
+    "identity": {
+        "resolverContext": {
+            "userId": "123456789"
+        }
+    },
+    "Info": {
+        "fieldName": "exampleMutation",
+        "parentTypeName": "Mutation",
+        "selectionSetGraphQL": "{\n  createdAt\n  id\n}",
+        "selectionSetList": [
+            "createdAt",
+            "id"
+        ]
+    },
+    "prev": "",
+    "Request": {
+        "Headers": {
+            "accept": "application/json, text/plain, */*",
+            "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "accept-encoding": "gzip, deflate, br",
+            "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+            "cloudfront-forwarded-proto": "https",
+            "cloudfront-is-desktop-viewer": "true",
+            "cloudfront-is-mobile-viewer": "false",
+            "cloudfront-is-smarttv-viewer": "false",
+            "cloudfront-viewer-country": "AU",
+            "cloudfront-is-tablet-viewer": "false",
+            "content-length": "374",
+            "content-type": "application/json",
+            "host": "test-application.appsync-api.ap-southeast-2.amazonaws.com",
+            "origin": "https://ap-southeast-2.console.aws.amazon.com",
+            "Referer": "https://ap-southeast-2.console.aws.amazon.com/",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "cross-site",
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36",
+            "via": "2.0 123123123123.cloudfront.net (CloudFront)",
+            "x-amz-cf-id": "123123123-456456456456456456==",
+            "x-amz-user-agent": "AWS-Console-AppSync/",
+            "x-amzn-trace-id": "Root=1-12333456-12334567899",
+            "x-api-key": "",
+            "x-forwarded-for": "0.0.0.0, 0.0.0.0",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        }
+    },
+    "source": null,
+    "stash": {}
+}


### PR DESCRIPTION
Adding lambda direct resolver request event to be used in cased where we are not using direct vtl integrations and require to be able to handle the event in a lambda. I have used this same event for months in production and it has worked out great. 