### PR TITLE
Support handlers that return io.Reader

### DIFF
--- a/lambda/entry.go
+++ b/lambda/entry.go
@@ -35,6 +35,9 @@ import (
 //
 // Where "TIn" and "TOut" are types compatible with the "encoding/json" standard library.
 // See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves
+//
+// "TOut" may also implement the io.Reader interface.
+// If "TOut" is both json serializable and implements io.Reader, then the json serialization is used.
 func Start(handler interface{}) {
 	StartWithOptions(handler)
 }

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/lambda/handlertrace"
 )
@@ -18,7 +20,7 @@ type Handler interface {
 }
 
 type handlerOptions struct {
-	Handler
+	handlerFunc
 	baseContext              context.Context
 	jsonResponseEscapeHTML   bool
 	jsonResponseIndentPrefix string
@@ -168,32 +170,57 @@ func newHandler(handlerFunc interface{}, options ...Option) *handlerOptions {
 	if h.enableSIGTERM {
 		enableSIGTERM(h.sigtermCallbacks)
 	}
-	h.Handler = reflectHandler(handlerFunc, h)
+	h.handlerFunc = reflectHandler(handlerFunc, h)
 	return h
 }
 
-type bytesHandlerFunc func(context.Context, []byte) ([]byte, error)
+type handlerFunc func(context.Context, []byte) (io.Reader, error)
 
-func (h bytesHandlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
-	return h(ctx, payload)
-}
-func errorHandler(err error) Handler {
-	return bytesHandlerFunc(func(_ context.Context, _ []byte) ([]byte, error) {
+// back-compat for the rpc mode
+func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
+	response, err := h(ctx, payload)
+	if err != nil {
 		return nil, err
-	})
+	}
+	b, err := io.ReadAll(response)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
-func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
-	if handlerFunc == nil {
+func errorHandler(err error) handlerFunc {
+	return func(_ context.Context, _ []byte) (io.Reader, error) {
+		return nil, err
+	}
+}
+
+type jsonOutBuffer struct {
+	*bytes.Buffer
+}
+
+func (j *jsonOutBuffer) ContentType() string {
+	return contentTypeJSON
+}
+
+func reflectHandler(f interface{}, h *handlerOptions) handlerFunc {
+	if f == nil {
 		return errorHandler(errors.New("handler is nil"))
 	}
 
-	if handler, ok := handlerFunc.(Handler); ok {
-		return handler
+	// back-compat: types with reciever `Invoke(context.Context, []byte) ([]byte, error)` need the return bytes wrapped
+	if handler, ok := f.(Handler); ok {
+		return func(ctx context.Context, payload []byte) (io.Reader, error) {
+			b, err := handler.Invoke(ctx, payload)
+			if err != nil {
+				return nil, err
+			}
+			return bytes.NewBuffer(b), nil
+		}
 	}
 
-	handler := reflect.ValueOf(handlerFunc)
-	handlerType := reflect.TypeOf(handlerFunc)
+	handler := reflect.ValueOf(f)
+	handlerType := reflect.TypeOf(f)
 	if handlerType.Kind() != reflect.Func {
 		return errorHandler(fmt.Errorf("handler kind %s is not %s", handlerType.Kind(), reflect.Func))
 	}
@@ -207,9 +234,10 @@ func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
 		return errorHandler(err)
 	}
 
-	return bytesHandlerFunc(func(ctx context.Context, payload []byte) ([]byte, error) {
+	out := &jsonOutBuffer{bytes.NewBuffer(nil)}
+	return func(ctx context.Context, payload []byte) (io.Reader, error) {
+		out.Reset()
 		in := bytes.NewBuffer(payload)
-		out := bytes.NewBuffer(nil)
 		decoder := json.NewDecoder(in)
 		encoder := json.NewEncoder(out)
 		encoder.SetEscapeHTML(h.jsonResponseEscapeHTML)
@@ -250,16 +278,24 @@ func reflectHandler(handlerFunc interface{}, h *handlerOptions) Handler {
 				trace.ResponseEvent(ctx, val)
 			}
 		}
+
+		// encode to JSON
 		if err := encoder.Encode(val); err != nil {
 			return nil, err
 		}
 
-		responseBytes := out.Bytes()
-		// back-compat, strip the encoder's trailing newline unless WithSetIndent was used
-		if h.jsonResponseIndentValue == "" && h.jsonResponseIndentPrefix == "" {
-			return responseBytes[:len(responseBytes)-1], nil
+		// if response value is an io.Reader, return it as-is
+		// back-compat, don't return the reader if the value serialized to a non-empty json
+		if reader, ok := val.(io.Reader); ok {
+			if strings.HasPrefix(out.String(), "{}") {
+				return reader, nil
+			}
 		}
 
-		return responseBytes, nil
-	})
+		// back-compat, strip the encoder's trailing newline unless WithSetIndent was used
+		if h.jsonResponseIndentValue == "" && h.jsonResponseIndentPrefix == "" {
+			out.Truncate(out.Len() - 1)
+		}
+		return out, nil
+	}
 }

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil" // nolint:staticcheck
 	"reflect"
 	"strings"
 
@@ -182,7 +183,7 @@ func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	b, err := io.ReadAll(response)
+	b, err := ioutil.ReadAll(response)
 	if err != nil {
 		return nil, err
 	}

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -187,6 +187,13 @@ func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error)
 	if response, ok := response.(io.Closer); ok {
 		defer response.Close()
 	}
+	// optimization: if the response is a *bytes.Buffer, a copy can be eliminated
+	switch response := response.(type) {
+	case *jsonOutBuffer:
+		return response.Bytes(), nil
+	case *bytes.Buffer:
+		return response.Bytes(), nil
+	}
 	b, err := ioutil.ReadAll(response)
 	if err != nil {
 		return nil, err

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -282,12 +282,16 @@ func reflectHandler(f interface{}, h *handlerOptions) handlerFunc {
 
 		// encode to JSON
 		if err := encoder.Encode(val); err != nil {
+			// if response is not JSON serializable, but the response type is a reader, return it as-is
+			if reader, ok := val.(io.Reader); ok {
+				return reader, nil
+			}
 			return nil, err
 		}
 
 		// if response value is an io.Reader, return it as-is
-		// back-compat, don't return the reader if the value serialized to a non-empty json
 		if reader, ok := val.(io.Reader); ok {
+			// back-compat, don't return the reader if the value serialized to a non-empty json
 			if strings.HasPrefix(out.String(), "{}") {
 				return reader, nil
 			}

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -183,6 +183,10 @@ func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+	// if the response needs to be closed (ex: net.Conn, os.File), ensure it's closed before the next invoke to prevent a resource leak
+	if response, ok := response.(io.Closer); ok {
+		defer response.Close()
+	}
 	b, err := ioutil.ReadAll(response)
 	if err != nil {
 		return nil, err

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -3,6 +3,7 @@
 package lambda
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -127,16 +128,20 @@ func TestInvokes(t *testing.T) {
 	}{
 		{
 			input:    `"Lambda"`,
-			expected: expected{`"Hello Lambda!"`, nil},
-			handler: func(name string) (string, error) {
-				return hello(name), nil
-			},
+			expected: expected{`null`, nil},
+			handler:  func(_ string) {},
 		},
 		{
 			input:    `"Lambda"`,
 			expected: expected{`"Hello Lambda!"`, nil},
 			handler: func(name string) (string, error) {
 				return hello(name), nil
+			},
+		},
+		{
+			expected: expected{`"Hello No Value!"`, nil},
+			handler: func(ctx context.Context) (string, error) {
+				return hello("No Value"), nil
 			},
 		},
 		{
@@ -260,6 +265,13 @@ func TestInvokes(t *testing.T) {
 			expected: expected{`<yolo>yolo</yolo>`, nil},
 			handler: func() (io.Reader, error) {
 				return strings.NewReader(`<yolo>yolo</yolo>`), nil
+			},
+		},
+		{
+			name:     "io.Reader responses that are byte buffers are passthrough",
+			expected: expected{`<yolo>yolo</yolo>`, nil},
+			handler: func() (*bytes.Buffer, error) {
+				return bytes.NewBuffer([]byte(`<yolo>yolo</yolo>`)), nil
 			},
 		},
 		{

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/ioutil" //nolint: staticcheck
 	"strings"
 	"testing"
 

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -278,7 +278,7 @@ func TestInvokes(t *testing.T) {
 		{
 			name:     "types that are not json serializable result in an error",
 			expected: expected{``, errors.New("json: error calling MarshalJSON for type struct { lambda.arbitraryJSON }: barf")},
-			handler: func() (any, error) {
+			handler: func() (interface{}, error) {
 				return struct {
 					arbitraryJSON
 				}{

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -83,6 +83,14 @@ func TestInvalidHandlers(t *testing.T) {
 	}
 }
 
+type staticHandler struct {
+	body []byte
+}
+
+func (h *staticHandler) Invoke(_ context.Context, _ []byte) ([]byte, error) {
+	return h.body, nil
+}
+
 type expected struct {
 	val string
 	err error
@@ -232,9 +240,7 @@ func TestInvokes(t *testing.T) {
 		{
 			name:     "Handler interface implementations are passthrough",
 			expected: expected{`<xml>hello</xml>`, nil},
-			handler: bytesHandlerFunc(func(_ context.Context, _ []byte) ([]byte, error) {
-				return []byte(`<xml>hello</xml>`), nil
-			}),
+			handler:  &staticHandler{body: []byte(`<xml>hello</xml>`)},
 		},
 	}
 	for i, testCase := range testCases {

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -82,12 +82,18 @@ func handleInvoke(invoke *invoke, handler *handlerOptions) error {
 		}
 		return nil
 	}
+	// if the response needs to be closed (ex: net.Conn, os.File), ensure it's closed before the next invoke to prevent a resource leak
+	if response, ok := response.(io.Closer); ok {
+		defer response.Close()
+	}
 
+	// if the response defines a content-type, plumb it through
 	contentType := contentTypeBytes
 	type ContentType interface{ ContentType() string }
-	if ct, ok := response.(ContentType); ok {
-		contentType = ct.ContentType()
+	if response, ok := response.(ContentType); ok {
+		contentType = response.ContentType()
 	}
+
 	if err := invoke.success(response, contentType); err != nil {
 		return fmt.Errorf("unexpected error occurred when sending the function functionResponse to the API: %v", err)
 	}

--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -3,9 +3,11 @@
 package lambda
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -70,7 +72,7 @@ func handleInvoke(invoke *invoke, handler *handlerOptions) error {
 	ctx = context.WithValue(ctx, "x-amzn-trace-id", traceID)
 
 	// call the handler, marshal any returned error
-	response, invokeErr := callBytesHandlerFunc(ctx, invoke.payload, handler.Handler.Invoke)
+	response, invokeErr := callBytesHandlerFunc(ctx, invoke.payload, handler.handlerFunc)
 	if invokeErr != nil {
 		if err := reportFailure(invoke, invokeErr); err != nil {
 			return err
@@ -80,7 +82,13 @@ func handleInvoke(invoke *invoke, handler *handlerOptions) error {
 		}
 		return nil
 	}
-	if err := invoke.success(response, contentTypeJSON); err != nil {
+
+	contentType := contentTypeBytes
+	type ContentType interface{ ContentType() string }
+	if ct, ok := response.(ContentType); ok {
+		contentType = ct.ContentType()
+	}
+	if err := invoke.success(response, contentType); err != nil {
 		return fmt.Errorf("unexpected error occurred when sending the function functionResponse to the API: %v", err)
 	}
 
@@ -90,13 +98,13 @@ func handleInvoke(invoke *invoke, handler *handlerOptions) error {
 func reportFailure(invoke *invoke, invokeErr *messages.InvokeResponse_Error) error {
 	errorPayload := safeMarshal(invokeErr)
 	log.Printf("%s", errorPayload)
-	if err := invoke.failure(errorPayload, contentTypeJSON); err != nil {
+	if err := invoke.failure(bytes.NewReader(errorPayload), contentTypeJSON); err != nil {
 		return fmt.Errorf("unexpected error occurred when sending the function error to the API: %v", err)
 	}
 	return nil
 }
 
-func callBytesHandlerFunc(ctx context.Context, payload []byte, handler bytesHandlerFunc) (response []byte, invokeErr *messages.InvokeResponse_Error) {
+func callBytesHandlerFunc(ctx context.Context, payload []byte, handler handlerFunc) (response io.Reader, invokeErr *messages.InvokeResponse_Error) {
 	defer func() {
 		if err := recover(); err != nil {
 			invokeErr = lambdaPanicResponse(err)

--- a/lambda/rpc_function_test.go
+++ b/lambda/rpc_function_test.go
@@ -261,7 +261,7 @@ func TestRPCModeInvokeClosesCloserIfResponseIsCloser(t *testing.T) {
 		reader: strings.NewReader("<yolo/>"),
 		closed: false,
 	}
-	srv := NewFunction(newHandler(func() (any, error) {
+	srv := NewFunction(newHandler(func() (interface{}, error) {
 		return handlerResource, nil
 	}))
 	var response messages.InvokeResponse
@@ -276,7 +276,7 @@ func TestRPCModeInvokeReaderErrorPropogated(t *testing.T) {
 		reader: &readerError{errors.New("yolo")},
 		closed: false,
 	}
-	srv := NewFunction(newHandler(func() (any, error) {
+	srv := NewFunction(newHandler(func() (interface{}, error) {
 		return handlerResource, nil
 	}))
 	var response messages.InvokeResponse

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -3,6 +3,7 @@
 package lambda
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil" //nolint: staticcheck
 	"net/http"
@@ -87,11 +88,11 @@ func TestClientDoneAndError(t *testing.T) {
 			client: client,
 		}
 		t.Run(fmt.Sprintf("happy Done with payload[%d]", i), func(t *testing.T) {
-			err := invoke.success(payload, contentTypeJSON)
+			err := invoke.success(bytes.NewReader(payload), contentTypeJSON)
 			assert.NoError(t, err)
 		})
 		t.Run(fmt.Sprintf("happy Error with payload[%d]", i), func(t *testing.T) {
-			err := invoke.failure(payload, contentTypeJSON)
+			err := invoke.failure(bytes.NewReader(payload), contentTypeJSON)
 			assert.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/195


*Description of changes:*

Without this change, to return arbitrary non-json bytes, a user must write something like this
```
type handler struct{}

func (h *handler) Invoke(_ context.Context, req []byte) ([]byte, error) {
	var name string
	if err := json.Unmarshal(req, &name); err != nil {
		return nil, err
	}
	return []byte("hello " + name), nil
}

func main() {
	lambda.Start(&handler)
}
```

This works, but isn't perfect:
1. extra boilerplate to define a type that can implement `Invoke`
2. handler is forced to implement it's own unmarshalling of the request

With this change, the above handler can be re-written like:

```
func main() {
	lambda.Start(func(name string) (io.Reader, error) {
		return strings.NewReader("hello " + name), nil
	})
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
