### PR TITLE
Add HandlerFunc generics support

### DIFF
--- a/lambda/entry_generic.go
+++ b/lambda/entry_generic.go
@@ -9,15 +9,24 @@ import (
 	"context"
 )
 
-// HandlerFunc represents a valid input with two arguments and two returns as described by Start
+// HandlerFunc represents a valid input with arguments and returns as described by Start
 type HandlerFunc[TIn, TOut any] interface {
-	func(context.Context, TIn) (TOut, error)
+	~func(context.Context, TIn) (TOut, error) |
+		~func() |
+		~func(TIn) |
+		~func() error |
+		~func(TIn) error |
+		~func() (TOut, error) |
+		~func(TIn) (TOut, error) |
+		~func(context.Context) |
+		~func(context.Context) error |
+		~func(context.Context) (TOut, error) |
+		~func(context.Context, TIn) |
+		~func(context.Context, TIn) error
 }
 
 // StartHandlerFunc is the same as StartWithOptions except that it takes a generic input
 // so that the function signature can be validated at compile time.
-//
-// Currently only the `func (context.Context, TIn) (TOut, error)` variant is supported
 func StartHandlerFunc[TIn any, TOut any, H HandlerFunc[TIn, TOut]](handler H, options ...Option) {
 	start(newHandler(handler, options...))
 }

--- a/lambda/entry_generic_test.go
+++ b/lambda/entry_generic_test.go
@@ -21,7 +21,7 @@ func TestStartHandlerFunc(t *testing.T) {
 	}
 
 	f := func(context.Context, any) (any, error) { return 1, nil }
-	StartHandlerFunc(f)
+	StartHandlerFunc[any, any](f)
 
 	assert.Equal(t, "expected AWS Lambda environment variables [_LAMBDA_SERVER_PORT AWS_LAMBDA_RUNTIME_API] are not defined", actual)
 


### PR DESCRIPTION
*Description of changes:*
Add generics for `HandlerFunc` interface for type-safe `StartHandlerFunc`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
