### PR TITLE
Add IoT Pre-provisioning hook Request and Response structs

### DIFF
--- a/events/iot_preprovision_hook.go
+++ b/events/iot_preprovision_hook.go
@@ -1,0 +1,19 @@
+package events
+
+// IoTPreProvisionHookRequest contains the request parameters for the IoT Pre-Provisioning Hook.
+// See https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html
+type IoTPreProvisionHookRequest struct {
+	ClaimCertificateID string            `json:"claimCertificateId"`
+	CertificateID      string            `json:"certificateId"`
+	CertificatePEM     string            `json:"certificatePem"`
+	TemplateARN        string            `json:"templateArn"`
+	ClientID           string            `json:"clientId"`
+	Parameters         map[string]string `json:"parameters"`
+}
+
+// IoTPreProvisionHookResponse contains the response parameters for the IoT Pre-Provisioning Hook.
+// See https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html
+type IoTPreProvisionHookResponse struct {
+	AllowProvisioning  bool              `json:"allowProvisioning"`
+	ParameterOverrides map[string]string `json:"parameterOverrides"`
+}

--- a/events/iot_preprovision_hook_test.go
+++ b/events/iot_preprovision_hook_test.go
@@ -1,0 +1,63 @@
+package events
+
+import (
+	"encoding/json"
+	"io/ioutil" //nolint: staticcheck
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events/test"
+)
+
+func TestIoTPreProvisionHookRequest(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/iot-preprovision-hook-request.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent IoTPreProvisionHookRequest
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
+func TestIoTPreProvisionHookRequestMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, IoTPreProvisionHookRequest{})
+}
+
+func TestIoTPreProvisionHookResponseMarshaling(t *testing.T) {
+
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/iot-preprovision-hook-response.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into Go object
+	var inputEvent IoTPreProvisionHookResponse
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
+func TestIoTPreProvisionHookResponseMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, IoTPreProvisionHookResponse{})
+}

--- a/events/testdata/iot-preprovision-hook-request.json
+++ b/events/testdata/iot-preprovision-hook-request.json
@@ -1,0 +1,11 @@
+{
+  "claimCertificateId" : "string",
+  "certificateId" : "string",
+  "certificatePem" : "string",
+  "templateArn" : "arn:aws:iot:us-east-1:1234567890:provisioningtemplate/MyTemplate",
+  "clientId" : "221a6d10-9c7f-42f1-9153-e52e6fc869c1",
+  "parameters" : {
+    "param1" : "parma1value",
+    "param2" : "param2value"
+  }
+}

--- a/events/testdata/iot-preprovision-hook-response.json
+++ b/events/testdata/iot-preprovision-hook-response.json
@@ -1,0 +1,7 @@
+{
+  "allowProvisioning": true,
+  "parameterOverrides" : {
+    "Key1": "newCustomValue1",
+    "Key2": "newCustomValue2"
+  }
+}


### PR DESCRIPTION
*Description of changes:*


Adds support for IoT Pre-provisioning hook requests and responses.

See https://docs.aws.amazon.com/iot/latest/developerguide/pre-provisioning-hook.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice