### PR TITLE
Implement CodePipelineEventDetailExecutionResult

### DIFF
--- a/events/codepipeline_cloudwatch.go
+++ b/events/codepipeline_cloudwatch.go
@@ -93,6 +93,8 @@ type CodePipelineEventDetail struct {
 	Region string `json:"region"`
 
 	Type CodePipelineEventDetailType `json:"type,omitempty"`
+
+	ExecutionResult CodePipelineEventDetailExecutionResult `json:"execution-result,omitempty"`
 }
 
 type CodePipelineEventDetailType struct {
@@ -104,4 +106,14 @@ type CodePipelineEventDetailType struct {
 
 	// From published EventBridge schema registry this is always int64 not string as documented
 	Version int64 `json:"version"`
+}
+
+type CodePipelineEventDetailExecutionResult struct {
+	ExternalExecutionUrl string `json:"external-execution-url"`
+
+	ExternalExecutionSummary string `json:"external-execution-summary"`
+
+	ExternalExecutionID string `json:"external-execution-id"`
+
+	ErrorCode string `json:"error-code,omitempty"`
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-go/issues/485 : Missing execution-result in CodePipelineEventDetail
See https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html


*Description of changes:*
Add a new type: `CodePipelineEventDetailExecutionResult`
Add a new optional field `ExecutionResult` to `CodePipelineEventDetail`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
