### PR TITLE
WIP - Add lambda.Option lambda.WithSetup

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -28,6 +28,7 @@ type handlerOptions struct {
 	jsonResponseIndentValue  string
 	enableSIGTERM            bool
 	sigtermCallbacks         []func()
+	setupFuncs               []func() error
 }
 
 type Option func(*handlerOptions)
@@ -99,6 +100,15 @@ func WithEnableSIGTERM(callbacks ...func()) Option {
 	return Option(func(h *handlerOptions) {
 		h.sigtermCallbacks = append(h.sigtermCallbacks, callbacks...)
 		h.enableSIGTERM = true
+	})
+}
+
+// WithSetup enables capturing of errors or panics that occur before the function is ready to handle invokes.
+// The provided functions will be run a single time, in order, before the runtime reports itself ready to recieve invokes.
+// If any of the provided functions returns an error, or panics, the error will be serialized and reported to the Runtime API.
+func WithSetup(funcs ...func() error) Option {
+	return Option(func(h *handlerOptions) {
+		h.setupFuncs = append(h.setupFuncs, funcs...)
 	})
 }
 

--- a/lambda/rpc_function.go
+++ b/lambda/rpc_function.go
@@ -33,11 +33,19 @@ func init() {
 }
 
 func startFunctionRPC(port string, handler Handler) error {
+	rpcFunction := NewFunction(handler)
+	if len(rpcFunction.handler.setupFuncs) > 0 {
+		runtimeAPIClient := newRuntimeAPIClient(os.Getenv("AWS_LAMBDA_RUNTIME_API"))
+		if err := handleSetup(runtimeAPIClient, rpcFunction.handler); err != nil {
+			return err
+		}
+	}
+
 	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = rpc.Register(NewFunction(handler))
+	err = rpc.Register(rpcFunction)
 	if err != nil {
 		log.Fatal("failed to register handler function")
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Re-posting for visibility, not yet ready for merge. This was unintentionally checked in with a linter fix https://github.com/aws/aws-lambda-go/pull/487 and released in v1.39.0 and yanked in v1.39.1


----

Adds an option to run initialization functions within a panic wrapper. This enables errors during setup to be gracefully reported to the platform, instead of the current behavior of appearing the same as an uncontrolled process exit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
