### PR TITLE
lint: remove `io/ioutil`

### DIFF
--- a/cfn/event_test.go
+++ b/cfn/event_test.go
@@ -4,7 +4,7 @@ package cfn
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -13,7 +13,7 @@ import (
 func TestCloudFormationEventMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cloudformation-event.json")
+	inputJSON, err := os.ReadFile("./testdata/cloudformation-event.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/cfn/response.go
+++ b/cfn/response.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil" //nolint: staticcheck
+	"io"
 	"log"
 	"net/http"
 )
@@ -67,7 +67,7 @@ func (r *Response) sendWith(client httpClient) error {
 		return err
 	}
 
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/cfn/wrap_test.go
+++ b/cfn/wrap_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil" //nolint: staticcheck
+	"io"
 	"net/http"
 	"testing"
 
@@ -151,7 +151,7 @@ func TestWrappedSendFailure(t *testing.T) {
 func extractResponseBody(t *testing.T, req *http.Request) Response {
 	assert.NotContains(t, req.Header, "Content-Type")
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	assert.NoError(t, err)
 	var response Response
 	err = json.Unmarshal(body, &response)

--- a/cmd/build-lambda-zip/main.go
+++ b/cmd/build-lambda-zip/main.go
@@ -6,8 +6,7 @@ import (
 	"archive/zip"
 	"flag"
 	"fmt"
-	"io/ioutil" //nolint: staticcheck
-	"log"
+		"log"
 	"os"
 	"path/filepath"
 )
@@ -82,7 +81,7 @@ func compressExeAndArgs(outZipPath string, exePath string, args []string) error 
 
 	zipWriter := zip.NewWriter(zipFile)
 	defer zipWriter.Close()
-	data, err := ioutil.ReadFile(exePath)
+	data, err := os.ReadFile(exePath)
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func compressExeAndArgs(outZipPath string, exePath string, args []string) error 
 		if err != nil {
 			return err
 		}
-		data, err := ioutil.ReadFile(arg)
+		data, err := os.ReadFile(arg)
 		if err != nil {
 			return err
 		}

--- a/cmd/build-lambda-zip/main_test.go
+++ b/cmd/build-lambda-zip/main_test.go
@@ -5,7 +5,7 @@ package main
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil" //nolint: staticcheck
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -34,7 +34,7 @@ func TestSizes(t *testing.T) {
 	}
 	testDir, err := os.Getwd()
 	require.NoError(t, err)
-	tempDir, err := ioutil.TempDir("/tmp", "build-lambda-zip")
+	tempDir, err := os.MkdirTemp("/tmp", "build-lambda-zip")
 	require.NoError(t, err)
 	for _, test := range cases {
 		require.NoError(t, os.Chdir(testDir))
@@ -66,7 +66,7 @@ func TestSizes(t *testing.T) {
 }
 
 func TestCompressExeAndArgs(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "build-lambda-zip")
+	tempDir, err := os.MkdirTemp("/tmp", "build-lambda-zip")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
@@ -117,7 +117,7 @@ func TestCompressExeAndArgs(t *testing.T) {
 		link, err := bootstrap.Open()
 		require.NoError(t, err)
 		defer link.Close()
-		linkTarget, err := ioutil.ReadAll(link)
+		linkTarget, err := io.ReadAll(link)
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Base(filePaths[0]), string(linkTarget))
 	})
@@ -148,7 +148,7 @@ func TestCompressExeAndArgs(t *testing.T) {
 				f, err := zf.Open()
 				require.NoError(t, err)
 				defer f.Close()
-				content, err := ioutil.ReadAll(f)
+				content, err := io.ReadAll(f)
 				require.NoError(t, err)
 				assert.Equal(t, fmt.Sprintf("Hello file %d!", expectedIndex), string(content), "in file: %s", zf.Name)
 				expectedIndex++

--- a/events/alb_test.go
+++ b/events/alb_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -16,7 +16,7 @@ func TestALBTargetRequestMarshaling(t *testing.T) {
 
 	for _, filename := range inputFiles {
 		// read json from file
-		inputJSON, err := ioutil.ReadFile(filename)
+		inputJSON, err := os.ReadFile(filename)
 		if err != nil {
 			t.Errorf("could not open test file. details: %v", err)
 		}
@@ -43,7 +43,7 @@ func TestALBTargetRequestMalformedJson(t *testing.T) {
 func TestALBTargetResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/alb-lambda-target-response.json")
+	inputJSON, err := os.ReadFile("./testdata/alb-lambda-target-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -4,8 +4,8 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
 	"testing"
+	"os"
 
 	"github.com/aws/aws-lambda-go/events/test"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +14,7 @@ import (
 func TestApiGatewayRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestApiGatewayRequestMalformedJson(t *testing.T) {
 func TestApiGatewayResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-response.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestApiGatewayResponseMalformedJson(t *testing.T) {
 func TestApiGatewayCustomAuthorizerRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-custom-auth-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestApiGatewayCustomAuthorizerRequestMarshaling(t *testing.T) {
 func TestApiGatewayCustomAuthorizerRequestTypeRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-request-type-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-custom-auth-request-type-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestApiGatewayCustomAuthorizerRequestTypeRequestMalformedJson(t *testing.T)
 func TestApiGatewayWebsocketRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-websocket-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-websocket-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestApiGatewayWebsocketRequestMalformedJson(t *testing.T) {
 func TestApiGatewayCustomAuthorizerResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-custom-auth-response.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-custom-auth-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestApiGatewayCustomAuthorizerResponseMalformedJson(t *testing.T) {
 func TestApiGatewayRestApiOpenApiRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-restapi-openapi-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-restapi-openapi-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestApiGatewayRestApiOpenApiRequestMarshaling(t *testing.T) {
 func TestApiGatewayV2HTTPRequestJWTAuthorizerMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-request-jwt-authorizer.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-request-jwt-authorizer.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestApiGatewayV2HTTPRequestJWTAuthorizerMarshaling(t *testing.T) {
 func TestApiGatewayV2HTTPRequestLambdaAuthorizerMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-request-lambda-authorizer.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-request-lambda-authorizer.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestApiGatewayV2HTTPRequestLambdaAuthorizerMarshaling(t *testing.T) {
 func TestApiGatewayV2HTTPRequestIAMMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-request-iam.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-request-iam.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestApiGatewayV2HTTPRequestIAMMarshaling(t *testing.T) {
 func TestApiGatewayV2HTTPRequestNoAuthorizerMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-request-no-authorizer.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-request-no-authorizer.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestApiGatewayV2HTTPRequestNoAuthorizerMarshaling(t *testing.T) {
 }
 
 func TestApiGatewayV2CustomAuthorizerV1RequestMarshaling(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-custom-authorizer-v1-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-custom-authorizer-v1-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestApiGatewayV2CustomAuthorizerV1RequestMarshaling(t *testing.T) {
 }
 
 func TestApiGatewayV2CustomAuthorizerV2RequestMarshaling(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/apigw-v2-custom-authorizer-v2-request.json")
+	inputJSON, err := os.ReadFile("./testdata/apigw-v2-custom-authorizer-v2-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/appsync_test.go
+++ b/events/appsync_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAppSyncIdentity_IAM(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/appsync-identity-iam.json")
+	inputJSON, err := os.ReadFile("./testdata/appsync-identity-iam.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestAppSyncIdentity_IAM(t *testing.T) {
 }
 
 func TestAppSyncIdentity_Cognito(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/appsync-identity-cognito.json")
+	inputJSON, err := os.ReadFile("./testdata/appsync-identity-cognito.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestAppSyncIdentity_Cognito(t *testing.T) {
 }
 
 func TestAppSyncLambdaAuthorizerRequestMarshalling(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/appsync-lambda-auth-request.json")
+	inputJSON, err := os.ReadFile("./testdata/appsync-lambda-auth-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestAppSyncLambdaAuthorizerRequestMalformedJson(t *testing.T) {
 }
 
 func TestAppSyncLambdaAuthorizerResponseMarshalling(t *testing.T) {
-	inputJSON, err := ioutil.ReadFile("./testdata/appsync-lambda-auth-response.json")
+	inputJSON, err := os.ReadFile("./testdata/appsync-lambda-auth-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/clientvpn_test.go
+++ b/events/clientvpn_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -11,7 +11,7 @@ import (
 
 func TestClientVPNConnectionHandlerRequestMarshaling(t *testing.T) {
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/clientvpn-connectionhandler-request.json")
+	inputJSON, err := os.ReadFile("./testdata/clientvpn-connectionhandler-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/codebuild_test.go
+++ b/events/codebuild_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 	"time"
 
@@ -301,7 +301,7 @@ func TestUnmarshalCodeBuildEvent(t *testing.T) {
 	}
 
 	for _, testcase := range tests {
-		data, err := ioutil.ReadFile(testcase.input)
+		data, err := os.ReadFile(testcase.input)
 		require.NoError(t, err)
 
 		var actual CodeBuildEvent

--- a/events/codedeploy_test.go
+++ b/events/codedeploy_test.go
@@ -3,7 +3,7 @@ package events
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/require"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 	"time"
 )
@@ -67,7 +67,7 @@ func TestUnmarshalCodeDeployEvent(t *testing.T) {
 	}
 
 	for _, testcase := range tests {
-		data, err := ioutil.ReadFile(testcase.input)
+		data, err := os.ReadFile(testcase.input)
 		require.NoError(t, err)
 
 		var actual CodeDeployEvent

--- a/events/codepipeline_cloudwatch_test.go
+++ b/events/codepipeline_cloudwatch_test.go
@@ -3,7 +3,7 @@ package events
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/require"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 	"time"
 )
@@ -88,7 +88,7 @@ func TestUnmarshalCodePipelineEvent(t *testing.T) {
 	}
 
 	for _, testcase := range tests {
-		data, err := ioutil.ReadFile(testcase.input)
+		data, err := os.ReadFile(testcase.input)
 		require.NoError(t, err)
 
 		var actual CodePipelineCloudWatchEvent

--- a/events/codepipeline_job_test.go
+++ b/events/codepipeline_job_test.go
@@ -3,7 +3,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -13,7 +13,7 @@ import (
 func TestCodePipeLineJobEventMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/codepipeline-job-event.json")
+	inputJSON, err := os.ReadFile("./testdata/codepipeline-job-event.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/codepipeline_test.go
+++ b/events/codepipeline_test.go
@@ -3,7 +3,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -13,7 +13,7 @@ import (
 func TestCodePipeLineEventMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/codepipeline-job-event.json")
+	inputJSON, err := os.ReadFile("./testdata/codepipeline-job-event.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/cognito_test.go
+++ b/events/cognito_test.go
@@ -3,7 +3,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -13,7 +13,7 @@ import (
 func TestCognitoEventMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestCognitoMarshalingMalformedJson(t *testing.T) {
 func TestCognitoEventUserPoolsPreSignupMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-presignup.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-presignup.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestCognitoUserPoolsPreSignupMarshalingMalformedJson(t *testing.T) {
 func TestCognitoEventUserPoolsPreAuthenticationMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-preauthentication.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-preauthentication.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestCognitoUserPoolsPreAuthenticationMarshalingMalformedJson(t *testing.T) 
 func TestCognitoEventUserPoolsPostConfirmationMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-postconfirmation.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-postconfirmation.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestCognitoEventUserPoolsPreTokenGenMarshalingMalformedJson(t *testing.T) {
 
 func TestCognitoEventUserPoolsPreTokenGenMarshaling(t *testing.T) {
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-pretokengen.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-pretokengen.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestCognitoEventUserPoolsVerifyAuthChallengeMalformedJson(t *testing.T) {
 func TestCognitoEventUserPoolsPostAuthenticationMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-postauthentication.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-postauthentication.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestCognitoEventUserPoolsMigrateUserMarshalingMalformedJson(t *testing.T) {
 
 func TestCognitoEventUserPoolsMigrateUserMarshaling(t *testing.T) {
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-migrateuser.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-migrateuser.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestCognitoEventUserPoolsMigrateUserMarshaling(t *testing.T) {
 
 func TestCognitoEventUserPoolsCustomMessageMarshaling(t *testing.T) {
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-custommessage.json")
+	inputJSON, err := os.ReadFile("./testdata/cognito-event-userpools-custommessage.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/config_test.go
+++ b/events/config_test.go
@@ -3,7 +3,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -12,7 +12,7 @@ import (
 
 func TestConfigEventMarshaling(t *testing.T) {
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/config-event.json")
+	inputJSON, err := os.ReadFile("./testdata/config-event.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/iot_preprovision_hook_test.go
+++ b/events/iot_preprovision_hook_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -11,7 +11,7 @@ import (
 func TestIoTPreProvisionHookRequest(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/iot-preprovision-hook-request.json")
+	inputJSON, err := os.ReadFile("./testdata/iot-preprovision-hook-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestIoTPreProvisionHookRequestMalformedJson(t *testing.T) {
 func TestIoTPreProvisionHookResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/iot-preprovision-hook-response.json")
+	inputJSON, err := os.ReadFile("./testdata/iot-preprovision-hook-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/iot_test.go
+++ b/events/iot_test.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events/test"
@@ -11,7 +11,7 @@ import (
 func TestIoTCoreCustomAuthorizerRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/iot-custom-auth-request.json")
+	inputJSON, err := os.ReadFile("./testdata/iot-custom-auth-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestIoTCoreCustomAuthorizerRequestMalformedJson(t *testing.T) {
 func TestIoTCoreCustomAuthorizerResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/iot-custom-auth-response.json")
+	inputJSON, err := os.ReadFile("./testdata/iot-custom-auth-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/lambda_function_urls_test.go
+++ b/events/lambda_function_urls_test.go
@@ -4,7 +4,7 @@ package events
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ import (
 func TestLambdaFunctionURLResponseMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/lambda-urls-response.json")
+	inputJSON, err := os.ReadFile("./testdata/lambda-urls-response.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestLambdaFunctionURLResponseMarshaling(t *testing.T) {
 func TestLambdaFunctionURLRequestMarshaling(t *testing.T) {
 
 	// read json from file
-	inputJSON, err := ioutil.ReadFile("./testdata/lambda-urls-request.json")
+	inputJSON, err := os.ReadFile("./testdata/lambda-urls-request.json")
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/test/assert.go
+++ b/events/test/assert.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"encoding/json"
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +10,7 @@ import (
 
 // nolint: stylecheck
 func AssertJsonFile(t *testing.T, file string, o interface{}) {
-	inputJSON, err := ioutil.ReadFile(file)
+	inputJSON, err := os.ReadFile(file)
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/events/test/readjson.go
+++ b/events/test/readjson.go
@@ -1,13 +1,13 @@
 package test
 
 import (
-	"io/ioutil" //nolint: staticcheck
+	"os"
 	"testing"
 )
 
 // ReadJSONFromFile reads a given input file to JSON
 func ReadJSONFromFile(t *testing.T, inputFile string) []byte {
-	inputJSON, err := ioutil.ReadFile(inputFile)
+	inputJSON, err := os.ReadFile(inputFile)
 	if err != nil {
 		t.Errorf("could not open test file. details: %v", err)
 	}

--- a/lambda/extensions_api_client.go
+++ b/lambda/extensions_api_client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil" //nolint: staticcheck
 	"net/http"
 )
 
@@ -53,7 +52,7 @@ func (c *extensionAPIClient) register(name string, events ...extensionAPIEventTy
 		return "", fmt.Errorf("failed to register extension: %v", err)
 	}
 	defer res.Body.Close()
-	_, _ = io.Copy(ioutil.Discard, res.Body)
+	_, _ = io.Copy(io.Discard, res.Body)
 
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("failed to register extension, got response status: %d %s", res.StatusCode, http.StatusText(res.StatusCode))
@@ -78,7 +77,7 @@ func (c *extensionAPIClient) next(id string) (response extensionEventResponse, e
 		return
 	}
 	defer res.Body.Close()
-	_, _ = io.Copy(ioutil.Discard, res.Body)
+	_, _ = io.Copy(io.Discard, res.Body)
 
 	if res.StatusCode != http.StatusOK {
 		err = fmt.Errorf("failed to register extension, got response status: %d %s", res.StatusCode, http.StatusText(res.StatusCode))

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil" // nolint:staticcheck
 	"reflect"
 	"strings"
 
@@ -210,7 +209,7 @@ func (h handlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error)
 	case *bytes.Buffer:
 		return response.Bytes(), nil
 	}
-	b, err := ioutil.ReadAll(response)
+	b, err := io.ReadAll(response)
 	if err != nil {
 		return nil, err
 	}

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil" //nolint: staticcheck
 	"strings"
 	"testing"
 	"time"
@@ -394,7 +393,7 @@ func TestInvokes(t *testing.T) {
 				} else {
 					assert.NoError(t, err)
 					require.NotNil(t, response)
-					responseBytes, err := ioutil.ReadAll(response)
+					responseBytes, err := io.ReadAll(response)
 					assert.NoError(t, err)
 					assert.Equal(t, testCase.expected.val, string(responseBytes))
 				}

--- a/lambda/runtime_api_client.go
+++ b/lambda/runtime_api_client.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil" //nolint: staticcheck
 	"log"
 	"net/http"
 	"runtime"
@@ -127,7 +126,7 @@ func (c *runtimeAPIClient) post(url string, body io.Reader, contentType string) 
 		return fmt.Errorf("failed to POST to %s: got unexpected status code: %d", url, resp.StatusCode)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return fmt.Errorf("something went wrong reading the POST response from %s: %v", url, err)
 	}

--- a/lambda/runtime_api_client_test.go
+++ b/lambda/runtime_api_client_test.go
@@ -5,7 +5,7 @@ package lambda
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil" //nolint: staticcheck
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,7 +69,7 @@ func TestClientDoneAndError(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		if strings.HasSuffix(r.URL.Path, "/error") {
 			capturedErrors = append(capturedErrors, body)
 		} else if strings.HasSuffix(r.URL.Path, "/response") {
@@ -115,7 +115,7 @@ func TestStatusCodes(t *testing.T) {
 			url := fmt.Sprintf("status-%d", i)
 
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, _ = ioutil.ReadAll(r.Body)
+				_, _ = io.ReadAll(r.Body)
 				w.WriteHeader(i)
 			}))
 

--- a/lambda/sigterm_test.go
+++ b/lambda/sigterm_test.go
@@ -4,7 +4,7 @@
 package lambda
 
 import (
-	"io/ioutil" //nolint: staticcheck
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -65,7 +65,7 @@ func TestEnableSigterm(t *testing.T) {
 			var logs string
 			done := make(chan interface{}) // closed on completion of log flush
 			go func() {
-				logBytes, err := ioutil.ReadAll(stdout)
+				logBytes, err := io.ReadAll(stdout)
 				require.NoError(t, err)
 				logs = string(logBytes)
 				close(done)
@@ -80,7 +80,7 @@ func TestEnableSigterm(t *testing.T) {
 			resp, err := client.Post(rieInvokeAPI, "application/json", strings.NewReader("{}"))
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, string(body), "Task timed out after 2.00 seconds")
 


### PR DESCRIPTION
*Description of changes:*
io/ioutil is deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
