### PR TITLE
Retract v1.39.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v1.39.0


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/491

*Description of changes:*

ran `go mod edit -retract=v1.39.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
