### PR TITLE
Add a note about lambda.norpc to the godoc of LambdaFunctionURLStreamingResponse

### DIFF
--- a/events/lambda_function_urls.go
+++ b/events/lambda_function_urls.go
@@ -82,6 +82,8 @@ type LambdaFunctionURLResponse struct {
 //			Body: strings.NewReader("<html><body>Hello World!</body></html>"),
 //		}, nil
 //	})
+//
+// Note: This response type requires compiling with `-tags lambda.norpc`, or choosing the `provided` or `provided.al2` runtime.
 type LambdaFunctionURLStreamingResponse struct {
 	prelude *bytes.Buffer
 


### PR DESCRIPTION
*Description of changes:*

Small doc update - the `go1.x` runtime doesn't support content-typed response structs unless the bander binary is compiled with `-tags lambda.norpc`, which then causes it to behave like the `provided` or `provided.al2` runtimes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
