### PR TITLE
feat: add ECSContainerInstanceEvent

### DIFF
--- a/events/README_ECS_ContainerInstance.md
+++ b/events/README_ECS_ContainerInstance.md
@@ -1,0 +1,26 @@
+# Sample Function
+
+The following is a sample class and Lambda function that receives Amazon ECS Container instance state change events record data as an input and writes some of the record data to CloudWatch Logs. (Note that anything written to stdout or stderr will be logged as CloudWatch Logs events.)
+
+```go
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+func handler(ctx context.Context, ecsEvent events.ECSContainerInstanceEvent) {
+	outputJSON, _ := json.MarshalIndent(ecsEvent, "", " ")
+	fmt.Printf("Data = %s", outputJSON)
+}
+
+func main() {
+	lambda.Start(handler)
+}
+
+```

--- a/events/ecs_container_instance.go
+++ b/events/ecs_container_instance.go
@@ -18,39 +18,39 @@ type ECSContainerInstanceEvent struct {
 }
 
 type ECSContainerInstanceEventDetailType struct {
-	AgentConnected       bool        `json:"agentConnected"`
-	Attributes           []Attribute `json:"attributes"`
-	ClusterARN           string      `json:"clusterArn"`
-	ContainerInstanceARN string      `json:"containerInstanceArn"`
-	EC2InstanceID        string      `json:"ec2InstanceId"`
-	RegisteredResources  []Resource  `json:"registeredResources"`
-	RemainingResources   []Resource  `json:"remainingResources"`
-	Status               string      `json:"status"`
-	Version              int         `json:"version"`
-	VersionInfo          VersionInfo `json:"versionInfo"`
-	UpdatedAt            time.Time   `json:"updatedAt"`
+	AgentConnected       bool                                 `json:"agentConnected"`
+	Attributes           []ECSContainerInstanceEventAttribute `json:"attributes"`
+	ClusterARN           string                               `json:"clusterArn"`
+	ContainerInstanceARN string                               `json:"containerInstanceArn"`
+	EC2InstanceID        string                               `json:"ec2InstanceId"`
+	RegisteredResources  []ECSContainerInstanceEventResource  `json:"registeredResources"`
+	RemainingResources   []ECSContainerInstanceEventResource  `json:"remainingResources"`
+	Status               string                               `json:"status"`
+	Version              int                                  `json:"version"`
+	VersionInfo          ECSContainerInstanceEventVersionInfo `json:"versionInfo"`
+	UpdatedAt            time.Time                            `json:"updatedAt"`
 }
 
-type Attribute struct {
+type ECSContainerInstanceEventAttribute struct {
 	Name string `json:"name"`
 }
 
-type Resource struct {
+type ECSContainerInstanceEventResource struct {
 	Name           string    `json:"name"`
 	Type           string    `json:"type"`
 	IntegerValue   int       `json:"integerValue,omitempty"`
 	StringSetValue []*string `json:"stringSetValue,omitempty"`
 }
 
-type VersionInfo struct {
+type ECSContainerInstanceEventVersionInfo struct {
 	AgentHash     string `json:"agentHash"`
 	AgentVersion  string `json:"agentVersion"`
 	DockerVersion string `json:"dockerVersion"`
 }
 
-// MarshalJSON implements cuustom marshaling to marshal the struct into JSON format while preserving an empty string slice in `StringSetValue` field.
-func (r Resource) MarshalJSON() ([]byte, error) {
-	type Alias Resource
+// MarshalJSON implements custom marshaling to marshal the struct into JSON format while preserving an empty string slice in `StringSetValue` field.
+func (r ECSContainerInstanceEventResource) MarshalJSON() ([]byte, error) {
+	type Alias ECSContainerInstanceEventResource
 	aux := struct {
 		StringSetValue json.RawMessage `json:"stringSetValue,omitempty"`
 		Alias

--- a/events/ecs_container_instance.go
+++ b/events/ecs_container_instance.go
@@ -1,0 +1,70 @@
+package events
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type ECSContainerInstanceEvent struct {
+	Version    string                              `json:"version"`
+	ID         string                              `json:"id"`
+	DetailType string                              `json:"detail-type"`
+	Source     string                              `json:"source"`
+	Account    string                              `json:"account"`
+	Time       time.Time                           `json:"time"`
+	Region     string                              `json:"region"`
+	Resources  []string                            `json:"resources"`
+	Detail     ECSContainerInstanceEventDetailType `json:"detail"`
+}
+
+type ECSContainerInstanceEventDetailType struct {
+	AgentConnected       bool        `json:"agentConnected"`
+	Attributes           []Attribute `json:"attributes"`
+	ClusterARN           string      `json:"clusterArn"`
+	ContainerInstanceARN string      `json:"containerInstanceArn"`
+	EC2InstanceID        string      `json:"ec2InstanceId"`
+	RegisteredResources  []Resource  `json:"registeredResources"`
+	RemainingResources   []Resource  `json:"remainingResources"`
+	Status               string      `json:"status"`
+	Version              int         `json:"version"`
+	VersionInfo          VersionInfo `json:"versionInfo"`
+	UpdatedAt            time.Time   `json:"updatedAt"`
+}
+
+type Attribute struct {
+	Name string `json:"name"`
+}
+
+type Resource struct {
+	Name           string    `json:"name"`
+	Type           string    `json:"type"`
+	IntegerValue   int       `json:"integerValue,omitempty"`
+	StringSetValue []*string `json:"stringSetValue,omitempty"`
+}
+
+type VersionInfo struct {
+	AgentHash     string `json:"agentHash"`
+	AgentVersion  string `json:"agentVersion"`
+	DockerVersion string `json:"dockerVersion"`
+}
+
+// MarshalJSON implements cuustom marshaling to marshal the struct into JSON format while preserving an empty string slice in `StringSetValue` field.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	type Alias Resource
+	aux := struct {
+		StringSetValue json.RawMessage `json:"stringSetValue,omitempty"`
+		Alias
+	}{
+		Alias: (Alias)(r),
+	}
+
+	if r.StringSetValue != nil {
+		b, err := json.Marshal(r.StringSetValue)
+		if err != nil {
+			return nil, err
+		}
+		aux.StringSetValue = b
+	}
+
+	return json.Marshal(&aux)
+}

--- a/events/ecs_container_instance_test.go
+++ b/events/ecs_container_instance_test.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestECSContainerInstanceEventMarshaling(t *testing.T) {
+	// 1. read JSON from file
+	inputJSON := test.ReadJSONFromFile(t, "./testdata/ecs-container-instance-state-change.json")
+
+	// 2. de-serialize into Go object
+	var inputEvent ECSContainerInstanceEvent
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// 3. Verify values populated into Go Object, at least one validation per data type
+	assert.Equal(t, "0", inputEvent.Version)
+	assert.Equal(t, "8952ba83-7be2-4ab5-9c32-6687532d15a2", inputEvent.ID)
+	assert.Equal(t, "ECS Container Instance State Change", inputEvent.DetailType)
+	assert.Equal(t, "aws.ecs", inputEvent.Source)
+	assert.Equal(t, "111122223333", inputEvent.Account)
+	assert.Equal(t, "us-east-1", inputEvent.Region)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:111122223333:container-instance/b54a2a04-046f-4331-9d74-3f6d7f6ca315", inputEvent.Resources[0])
+	testTime, err := time.Parse(time.RFC3339, "2016-12-06T16:41:06Z")
+	if err != nil {
+		t.Errorf("Failed to parse time: %v", err)
+	}
+	assert.Equal(t, testTime, inputEvent.Time)
+
+	var detail = inputEvent.Detail
+	assert.True(t, detail.AgentConnected)
+	assert.Equal(t, "com.amazonaws.ecs.capability.logging-driver.syslog", detail.Attributes[0].Name)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:111122223333:cluster/default", detail.ClusterARN)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:111122223333:container-instance/b54a2a04-046f-4331-9d74-3f6d7f6ca315", detail.ContainerInstanceARN)
+	assert.Equal(t, "i-f3a8506b", detail.EC2InstanceID)
+	assert.Equal(t, "CPU", detail.RegisteredResources[0].Name)
+	assert.Equal(t, "INTEGER", detail.RegisteredResources[0].Type)
+	assert.Equal(t, 2048, detail.RegisteredResources[0].IntegerValue)
+	assert.Equal(t, "MEMORY", detail.RegisteredResources[1].Name)
+	assert.Equal(t, "INTEGER", detail.RegisteredResources[1].Type)
+	assert.Equal(t, 3767, detail.RegisteredResources[1].IntegerValue)
+	assert.Equal(t, "PORTS", detail.RegisteredResources[2].Name)
+	assert.Equal(t, "STRINGSET", detail.RegisteredResources[2].Type)
+	assert.Equal(t, []*string{ptr("22"), ptr("2376"), ptr("2375"), ptr("51678"), ptr("51679")}, detail.RegisteredResources[2].StringSetValue)
+	assert.Equal(t, "PORTS_UDP", detail.RegisteredResources[3].Name)
+	assert.Equal(t, "STRINGSET", detail.RegisteredResources[3].Type)
+	assert.Equal(t, []*string{}, detail.RegisteredResources[3].StringSetValue)
+	assert.Equal(t, "CPU", detail.RemainingResources[0].Name)
+	assert.Equal(t, "INTEGER", detail.RemainingResources[0].Type)
+	assert.Equal(t, 1988, detail.RemainingResources[0].IntegerValue)
+	assert.Equal(t, "MEMORY", detail.RemainingResources[1].Name)
+	assert.Equal(t, "INTEGER", detail.RemainingResources[1].Type)
+	assert.Equal(t, 767, detail.RemainingResources[1].IntegerValue)
+	assert.Equal(t, "PORTS", detail.RemainingResources[2].Name)
+	assert.Equal(t, "STRINGSET", detail.RemainingResources[2].Type)
+	assert.Equal(t, []*string{ptr("22"), ptr("2376"), ptr("2375"), ptr("51678"), ptr("51679")}, detail.RemainingResources[2].StringSetValue)
+	assert.Equal(t, "PORTS_UDP", detail.RemainingResources[3].Name)
+	assert.Equal(t, "STRINGSET", detail.RemainingResources[3].Type)
+	assert.Equal(t, []*string{}, detail.RemainingResources[3].StringSetValue)
+	assert.Equal(t, "ACTIVE", detail.Status)
+	assert.Equal(t, 14801, detail.Version)
+	assert.Equal(t, "aebcbca", detail.VersionInfo.AgentHash)
+	assert.Equal(t, "1.13.0", detail.VersionInfo.AgentVersion)
+	assert.Equal(t, "DockerVersion: 1.11.2", detail.VersionInfo.DockerVersion)
+	testUpdateTime, err := time.Parse(time.RFC3339, "2016-12-06T16:41:06Z")
+	if err != nil {
+		t.Errorf("Failed to parse time: %v", err)
+	}
+	assert.Equal(t, testUpdateTime, inputEvent.Time)
+
+	// 4. serialize to JSON
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	// 5. check result
+	assert.JSONEq(t, string(inputJSON), string(outputJSON))
+}
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestECSContainerInstanceMarshalingMalformedJson(t *testing.T) {
+	test.TestMalformedJson(t, ECSContainerInstanceEvent{})
+}

--- a/events/ecs_container_instance_test.go
+++ b/events/ecs_container_instance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 package events
 
 import (

--- a/events/testdata/ecs-container-instance-state-change.json
+++ b/events/testdata/ecs-container-instance-state-change.json
@@ -1,0 +1,102 @@
+{
+	"version": "0",
+	"id": "8952ba83-7be2-4ab5-9c32-6687532d15a2",
+	"detail-type": "ECS Container Instance State Change",
+	"source": "aws.ecs",
+	"account": "111122223333",
+	"time": "2016-12-06T16:41:06Z",
+	"region": "us-east-1",
+	"resources": [
+		"arn:aws:ecs:us-east-1:111122223333:container-instance/b54a2a04-046f-4331-9d74-3f6d7f6ca315"
+	],
+	"detail": {
+		"agentConnected": true,
+		"attributes": [
+			{
+				"name": "com.amazonaws.ecs.capability.logging-driver.syslog"
+			},
+			{
+				"name": "com.amazonaws.ecs.capability.task-iam-role-network-host"
+			},
+			{
+				"name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+			},
+			{
+				"name": "com.amazonaws.ecs.capability.logging-driver.json-file"
+			},
+			{
+				"name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
+			},
+			{
+				"name": "com.amazonaws.ecs.capability.privileged-container"
+			}
+		],
+		"clusterArn": "arn:aws:ecs:us-east-1:111122223333:cluster/default",
+		"containerInstanceArn": "arn:aws:ecs:us-east-1:111122223333:container-instance/b54a2a04-046f-4331-9d74-3f6d7f6ca315",
+		"ec2InstanceId": "i-f3a8506b",
+		"registeredResources": [
+			{
+				"name": "CPU",
+				"type": "INTEGER",
+				"integerValue": 2048
+			},
+			{
+				"name": "MEMORY",
+				"type": "INTEGER",
+				"integerValue": 3767
+			},
+			{
+				"name": "PORTS",
+				"type": "STRINGSET",
+				"stringSetValue": [
+					"22",
+					"2376",
+					"2375",
+					"51678",
+					"51679"
+				]
+			},
+			{
+				"name": "PORTS_UDP",
+				"type": "STRINGSET",
+				"stringSetValue": []
+			}
+		],
+		"remainingResources": [
+			{
+				"name": "CPU",
+				"type": "INTEGER",
+				"integerValue": 1988
+			},
+			{
+				"name": "MEMORY",
+				"type": "INTEGER",
+				"integerValue": 767
+			},
+			{
+				"name": "PORTS",
+				"type": "STRINGSET",
+				"stringSetValue": [
+					"22",
+					"2376",
+					"2375",
+					"51678",
+					"51679"
+				]
+			},
+			{
+				"name": "PORTS_UDP",
+				"type": "STRINGSET",
+				"stringSetValue": []
+			}
+		],
+		"status": "ACTIVE",
+		"version": 14801,
+		"versionInfo": {
+			"agentHash": "aebcbca",
+			"agentVersion": "1.13.0",
+			"dockerVersion": "DockerVersion: 1.11.2"
+		},
+		"updatedAt": "2016-12-06T16:41:06.991Z"
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ref: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_container_instance_events

I verified in my environment.

<details>
<summary>Lambda code</summary>

```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"time"

	"github.com/aws/aws-lambda-go/lambda"
)

type ECSContainerInstanceEvent struct {
	Version    string                              `json:"version"`
	ID         string                              `json:"id"`
	DetailType string                              `json:"detail-type"`
	Source     string                              `json:"source"`
	Account    string                              `json:"account"`
	Time       time.Time                           `json:"time"`
	Region     string                              `json:"region"`
	Resources  []string                            `json:"resources"`
	Detail     ECSContainerInstanceEventDetailType `json:"detail"`
}

type ECSContainerInstanceEventDetailType struct {
	AgentConnected       bool        `json:"agentConnected"`
	Attributes           []Attribute `json:"attributes"`
	ClusterArn           string      `json:"clusterArn"`
	ContainerInstanceArn string      `json:"containerInstanceArn"`
	EC2InstanceID        string      `json:"ec2InstanceId"`
	RegisteredResources  []Resource  `json:"registeredResources"`
	RemainingResources   []Resource  `json:"remainingResources"`
	Status               string      `json:"status"`
	Version              int         `json:"version"`
	VersionInfo          VersionInfo `json:"versionInfo"`
	UpdatedAt            time.Time   `json:"updatedAt"`
}

type Attribute struct {
	Name string `json:"name"`
}

type Resource struct {
	Name           string    `json:"name"`
	Type           string    `json:"type"`
	IntegerValue   int       `json:"integerValue,omitempty"`
	StringSetValue []*string `json:"stringSetValue,omitempty"`
}

type VersionInfo struct {
	AgentHash     string `json:"agentHash"`
	AgentVersion  string `json:"agentVersion"`
	DockerVersion string `json:"dockerVersion"`
}

func (r Resource) MarshalJSON() ([]byte, error) {
	type Alias Resource
	aux := struct {
		StringSetValue json.RawMessage `json:"stringSetValue,omitempty"`
		Alias
	}{
		Alias: (Alias)(r),
	}

	if r.StringSetValue != nil {
		b, err := json.Marshal(r.StringSetValue)
		if err != nil {
			return nil, err
		}
		aux.StringSetValue = b
	}

	return json.Marshal(&aux)
}

func handler(ctx context.Context, ecsEvent ECSContainerInstanceEvent) {
	outputJSON, _ := json.MarshalIndent(ecsEvent, "", " ")
	fmt.Printf("output: %s", outputJSON)
}

func main() {
	lambda.Start(handler)
}
```
</details>

Change status to `DRAINING`

<details>
<summary>Cloudwatch Logs</summary>

```txt
  | 2023-04-16T12:59:37.095+01:00 | START RequestId: <START RequestId> Version: $LATEST
  | 2023-04-16T12:59:37.096+01:00 | err: <nil>
  | 2023-04-16T12:59:37.096+01:00 | output: {
  | 2023-04-16T12:59:37.096+01:00 | "version": "0",
  | 2023-04-16T12:59:37.096+01:00 | "id": "<id>",
  | 2023-04-16T12:59:37.096+01:00 | "detail-type": "ECS Container Instance State Change",
  | 2023-04-16T12:59:37.096+01:00 | "source": "aws.ecs",
  | 2023-04-16T12:59:37.096+01:00 | "account": "<account>",
  | 2023-04-16T12:59:37.096+01:00 | "time": "2023-04-16T11:59:36Z",
  | 2023-04-16T12:59:37.096+01:00 | "region": "eu-west-1",
  | 2023-04-16T12:59:37.096+01:00 | "resources": [
  | 2023-04-16T12:59:37.096+01:00 | "<resources>"
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "detail": {
  | 2023-04-16T12:59:37.096+01:00 | "agentConnected": false,
  | 2023-04-16T12:59:37.096+01:00 | "attributes": [
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "ecs.capability.secrets.asm.environment-variables"
  | 2023-04-16T12:59:37.096+01:00 | },
...
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "com.amazonaws.ecs.capability.task-iam-role"
  | 2023-04-16T12:59:37.096+01:00 | }
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "clusterArn": "<clusterArn>",
  | 2023-04-16T12:59:37.096+01:00 | "containerInstanceArn": "<containerInstanceArn>",
  | 2023-04-16T12:59:37.096+01:00 | "ec2InstanceId": "<ec2InstanceId>",
  | 2023-04-16T12:59:37.096+01:00 | "registeredResources": [
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "CPU",
  | 2023-04-16T12:59:37.096+01:00 | "type": "INTEGER",
  | 2023-04-16T12:59:37.096+01:00 | "integerValue": 1024
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "MEMORY",
  | 2023-04-16T12:59:37.096+01:00 | "type": "INTEGER",
  | 2023-04-16T12:59:37.096+01:00 | "integerValue": 970
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "stringSetValue": [
  | 2023-04-16T12:59:37.096+01:00 | "22",
  | 2023-04-16T12:59:37.096+01:00 | "2376",
  | 2023-04-16T12:59:37.096+01:00 | "2375",
  | 2023-04-16T12:59:37.096+01:00 | "51678",
  | 2023-04-16T12:59:37.096+01:00 | "51679"
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "name": "PORTS",
  | 2023-04-16T12:59:37.096+01:00 | "type": "STRINGSET"
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "stringSetValue": [],
  | 2023-04-16T12:59:37.096+01:00 | "name": "PORTS_UDP",
  | 2023-04-16T12:59:37.096+01:00 | "type": "STRINGSET"
  | 2023-04-16T12:59:37.096+01:00 | }
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "remainingResources": [
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "CPU",
  | 2023-04-16T12:59:37.096+01:00 | "type": "INTEGER",
  | 2023-04-16T12:59:37.096+01:00 | "integerValue": 1024
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "name": "MEMORY",
  | 2023-04-16T12:59:37.096+01:00 | "type": "INTEGER",
  | 2023-04-16T12:59:37.096+01:00 | "integerValue": 970
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "stringSetValue": [
  | 2023-04-16T12:59:37.096+01:00 | "22",
  | 2023-04-16T12:59:37.096+01:00 | "2376",
  | 2023-04-16T12:59:37.096+01:00 | "2375",
  | 2023-04-16T12:59:37.096+01:00 | "51678",
  | 2023-04-16T12:59:37.096+01:00 | "51679"
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "name": "PORTS",
  | 2023-04-16T12:59:37.096+01:00 | "type": "STRINGSET"
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | {
  | 2023-04-16T12:59:37.096+01:00 | "stringSetValue": [],
  | 2023-04-16T12:59:37.096+01:00 | "name": "PORTS_UDP",
  | 2023-04-16T12:59:37.096+01:00 | "type": "STRINGSET"
  | 2023-04-16T12:59:37.096+01:00 | }
  | 2023-04-16T12:59:37.096+01:00 | ],
  | 2023-04-16T12:59:37.096+01:00 | "status": "DRAINING",
  | 2023-04-16T12:59:37.096+01:00 | "version": 36,
  | 2023-04-16T12:59:37.096+01:00 | "versionInfo": {
  | 2023-04-16T12:59:37.096+01:00 | "agentHash": "<agentHash>",
  | 2023-04-16T12:59:37.096+01:00 | "agentVersion": "1.70.0",
  | 2023-04-16T12:59:37.096+01:00 | "dockerVersion": "DockerVersion: 20.10.17"
  | 2023-04-16T12:59:37.096+01:00 | },
  | 2023-04-16T12:59:37.096+01:00 | "updatedAt": "2023-04-16T11:59:36.836Z"
  | 2023-04-16T12:59:37.096+01:00 | }
  | 2023-04-16T12:59:37.097+01:00 | END RequestId: <END RequestId>
  | 2023-04-16T12:59:37.097+01:00 | REPORT RequestId: <REPORT RequestId> Duration: 1.65 ms Billed Duration: 2 ms Memory Size: 128 MB Max Memory Used: 31 MB
```

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
