### PR TITLE
added APIKeyID

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -195,6 +195,7 @@ type APIGatewayWebsocketProxyRequestContext struct {
 // APIGatewayCustomAuthorizerRequestTypeRequestIdentity contains identity information for the request caller including certificate information if using mTLS.
 type APIGatewayCustomAuthorizerRequestTypeRequestIdentity struct {
 	APIKey     string                                                         `json:"apiKey"`
+	APIKeyID   string                                                         `json:"apiKeyId"`
 	SourceIP   string                                                         `json:"sourceIp"`
 	ClientCert APIGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert `json:"clientCert"`
 }


### PR DESCRIPTION
Added the APIKeyID field. I see no reason to not have it there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
