### PR TITLE
feat: provide the options to set arbitrary json encoder and decoder options

### DIFF
--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -291,7 +291,7 @@ func TestInvokes(t *testing.T) {
 			input:    `{ "i": 1 }`,
 			expected: expected{`null`, nil},
 			handler: func(in struct {
-				I any `json:"i"`
+				I interface{} `json:"i"`
 			}) error {
 				if _, ok := in.I.(json.Number); !ok {
 					return fmt.Errorf("`i` was not of type json.Number: %T", in.I)
@@ -305,7 +305,7 @@ func TestInvokes(t *testing.T) {
 			input:    `{ "i": 1 }`,
 			expected: expected{`null`, nil},
 			handler: func(in struct {
-				I any `json:"i"`
+				I interface{} `json:"i"`
 			}) error {
 				if _, ok := in.I.(float64); !ok {
 					return fmt.Errorf("`i` was not of type float64: %T", in.I)


### PR DESCRIPTION
*Issue #:* https://github.com/aws/aws-lambda-go/issues/514

*Description of changes:*

Before this change, the lambda API supported setting some of the json encoder options (`SetEscapeHTML(...)` & `SetIndent(...)`). I needed the ability to set the `UseNumber()` option on the decoder and I considered setting it in the same way (by creating a one-off option), but instead I ended up creating two new options that allow setting arbitrary fields on the encoder and decoder.

I think this is a better option because it's future-proof (if new options are added to the json library, this library won't also need to be changed to make this option available) and more backward compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
