### PR TITLE
Plumb JSON Decoder options

### DIFF
--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -22,12 +22,14 @@ type Handler interface {
 
 type handlerOptions struct {
 	handlerFunc
-	baseContext              context.Context
-	jsonResponseEscapeHTML   bool
-	jsonResponseIndentPrefix string
-	jsonResponseIndentValue  string
-	enableSIGTERM            bool
-	sigtermCallbacks         []func()
+	baseContext                      context.Context
+	jsonRequestUseNumber             bool
+	jsonRequestDisallowUnknownFields bool
+	jsonResponseEscapeHTML           bool
+	jsonResponseIndentPrefix         string
+	jsonResponseIndentValue          string
+	enableSIGTERM                    bool
+	sigtermCallbacks                 []func()
 }
 
 type Option func(*handlerOptions)
@@ -78,6 +80,38 @@ func WithSetIndent(prefix, indent string) Option {
 	return Option(func(h *handlerOptions) {
 		h.jsonResponseIndentPrefix = prefix
 		h.jsonResponseIndentValue = indent
+	})
+}
+
+// WithUseNumber sets the UseNumber option on the underlying json decoder
+//
+// Usage:
+//
+//	lambda.StartWithOptions(
+//		func (event any) (any, error) {
+//			return event, nil
+//		},
+//		lambda.WithUseNumber(true)
+//	)
+func WithUseNumber(useNumber bool) Option {
+	return Option(func(h *handlerOptions) {
+		h.jsonRequestUseNumber = useNumber
+	})
+}
+
+// WithUseNumber sets the DisallowUnknownFields option on the underlying json decoder
+//
+// Usage:
+//
+//	lambda.StartWithOptions(
+//		func (event any) (any, error) {
+//			return event, nil
+//		},
+//		lambda.WithDisallowUnknownFields(true)
+//	)
+func WithDisallowUnknownFields(disallowUnknownFields bool) Option {
+	return Option(func(h *handlerOptions) {
+		h.jsonRequestDisallowUnknownFields = disallowUnknownFields
 	})
 }
 
@@ -267,6 +301,12 @@ func reflectHandler(f interface{}, h *handlerOptions) handlerFunc {
 		out.Reset()
 		in := bytes.NewBuffer(payload)
 		decoder := json.NewDecoder(in)
+		if h.jsonRequestUseNumber {
+			decoder.UseNumber()
+		}
+		if h.jsonRequestDisallowUnknownFields {
+			decoder.DisallowUnknownFields()
+		}
 		encoder := json.NewEncoder(out)
 		encoder.SetEscapeHTML(h.jsonResponseEscapeHTML)
 		encoder.SetIndent(h.jsonResponseIndentPrefix, h.jsonResponseIndentValue)

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil" //nolint: staticcheck
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -308,6 +309,33 @@ func TestInvokes(t *testing.T) {
 				return struct{ Foo string }{"Bar"}, nil
 			},
 			options: []Option{WithSetIndent(">>", "  ")},
+		},
+		{
+			name:     "WithUseNumber(true) results in json.Number instead of float64 when decoding to an interface{}",
+			input:    `19.99`,
+			expected: expected{`"Number"`, nil},
+			handler: func(event interface{}) (string, error) {
+				return reflect.TypeOf(event).Name(), nil
+			},
+			options: []Option{WithUseNumber(true)},
+		},
+		{
+			name:     "WithUseNumber(false)",
+			input:    `19.99`,
+			expected: expected{`"float64"`, nil},
+			handler: func(event interface{}) (string, error) {
+				return reflect.TypeOf(event).Name(), nil
+			},
+			options: []Option{WithUseNumber(false)},
+		},
+		{
+			name:     "No decoder options provided is the same as WithUseNumber(false)",
+			input:    `19.99`,
+			expected: expected{`"float64"`, nil},
+			handler: func(event interface{}) (string, error) {
+				return reflect.TypeOf(event).Name(), nil
+			},
+			options: []Option{},
 		},
 		{
 			name:     "bytes are base64 encoded strings",

--- a/lambda/handler_test.go
+++ b/lambda/handler_test.go
@@ -338,6 +338,27 @@ func TestInvokes(t *testing.T) {
 			options: []Option{},
 		},
 		{
+			name:     "WithDisallowUnknownFields(true)",
+			input:    `{"Hello": "World"}`,
+			expected: expected{"", errors.New(`json: unknown field "Hello"`)},
+			handler:  func(_ struct{}) {},
+			options:  []Option{WithDisallowUnknownFields(true)},
+		},
+		{
+			name:     "WithDisallowUnknownFields(false)",
+			input:    `{"Hello": "World"}`,
+			expected: expected{`null`, nil},
+			handler:  func(_ struct{}) {},
+			options:  []Option{WithDisallowUnknownFields(false)},
+		},
+		{
+			name:     "No decoder options provided is the same as WithDisallowUnknownFields(false)",
+			input:    `{"Hello": "World"}`,
+			expected: expected{`null`, nil},
+			handler:  func(_ struct{}) {},
+			options:  []Option{},
+		},
+		{
 			name:     "bytes are base64 encoded strings",
 			input:    `"aGVsbG8="`,
 			expected: expected{`"aGVsbG95b2xv"`, nil},


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-lambda-go/issues/514

*Description of changes:*

Adds options `lambda.WithUseNumber` and `lambda.WithDisallowUnknownFields`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
