### PR TITLE
Add options lambdaurl.WithDetectContentType and lambda.WithContextValue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ jobs:
     name: run tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go:
           - "1.21"

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -52,7 +52,7 @@ func WithContext(ctx context.Context) Option {
 }
 
 // WithContextValue adds a value to the handler context.
-// If a base context was set using WithContext, that base is used at the parent.
+// If a base context was set using WithContext, that base is used as the parent.
 //
 // Usage:
 //

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -23,7 +23,7 @@ type Handler interface {
 type handlerOptions struct {
 	handlerFunc
 	baseContext                      context.Context
-  contextValues                    map[interface{}]interface{}
+	contextValues                    map[interface{}]interface{}
 	jsonRequestUseNumber             bool
 	jsonRequestDisallowUnknownFields bool
 	jsonResponseEscapeHTML           bool

--- a/lambda/handler.go
+++ b/lambda/handler.go
@@ -23,6 +23,7 @@ type Handler interface {
 type handlerOptions struct {
 	handlerFunc
 	baseContext              context.Context
+	contextValues            map[interface{}]interface{}
 	jsonResponseEscapeHTML   bool
 	jsonResponseIndentPrefix string
 	jsonResponseIndentValue  string
@@ -45,6 +46,23 @@ type Option func(*handlerOptions)
 func WithContext(ctx context.Context) Option {
 	return Option(func(h *handlerOptions) {
 		h.baseContext = ctx
+	})
+}
+
+// WithContextValue adds a value to the handler context.
+// If a base context was set using WithContext, that base is used at the parent.
+//
+// Usage:
+//
+//	lambda.StartWithOptions(
+//	 	func (ctx context.Context) (string, error) {
+//	 		return ctx.Value("foo"), nil
+//	 	},
+//	 	lambda.WithContextValue("foo", "bar")
+//	)
+func WithContextValue(key interface{}, value interface{}) Option {
+	return Option(func(h *handlerOptions) {
+		h.contextValues[key] = value
 	})
 }
 
@@ -177,12 +195,16 @@ func newHandler(handlerFunc interface{}, options ...Option) *handlerOptions {
 	}
 	h := &handlerOptions{
 		baseContext:              context.Background(),
+		contextValues:            map[interface{}]interface{}{},
 		jsonResponseEscapeHTML:   false,
 		jsonResponseIndentPrefix: "",
 		jsonResponseIndentValue:  "",
 	}
 	for _, option := range options {
 		option(h)
+	}
+	for k, v := range h.contextValues {
+		h.baseContext = context.WithValue(h.baseContext, k, v)
 	}
 	if h.enableSIGTERM {
 		enableSIGTERM(h.sigtermCallbacks)

--- a/lambda/sigterm_test.go
+++ b/lambda/sigterm_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const ()
-
 func TestEnableSigterm(t *testing.T) {
 	if _, err := exec.LookPath("aws-lambda-rie"); err != nil {
 		t.Skipf("%v - install from https://github.com/aws/aws-lambda-runtime-interface-emulator/", err)

--- a/lambda/sigterm_test.go
+++ b/lambda/sigterm_test.go
@@ -5,7 +5,6 @@ package lambda
 
 import (
 	"io/ioutil" //nolint: staticcheck
-	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -32,6 +31,7 @@ func TestEnableSigterm(t *testing.T) {
 	handlerBuild.Stdout = os.Stderr
 	require.NoError(t, handlerBuild.Run())
 
+	portI := 0
 	for name, opts := range map[string]struct {
 		envVars    []string
 		assertLogs func(t *testing.T, logs string)
@@ -51,8 +51,9 @@ func TestEnableSigterm(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			addr1 := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
-			addr2 := "localhost:" + strconv.Itoa(9000+rand.Intn(999))
+			portI += 1
+			addr1 := "localhost:" + strconv.Itoa(8000+portI)
+			addr2 := "localhost:" + strconv.Itoa(9000+portI)
 			rieInvokeAPI := "http://" + addr1 + "/2015-03-31/functions/function/invocations"
 			// run the runtime interface emulator, capture the logs for assertion
 			cmd := exec.Command("aws-lambda-rie", "--runtime-interface-emulator-address", addr1, "--runtime-api-address", addr2, "sigterm.handler")

--- a/lambda/sigterm_test.go
+++ b/lambda/sigterm_test.go
@@ -5,10 +5,12 @@ package lambda
 
 import (
 	"io/ioutil" //nolint: staticcheck
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,9 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	rieInvokeAPI = "http://localhost:8080/2015-03-31/functions/function/invocations"
-)
+const ()
 
 func TestEnableSigterm(t *testing.T) {
 	if _, err := exec.LookPath("aws-lambda-rie"); err != nil {
@@ -53,8 +53,11 @@ func TestEnableSigterm(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			addr1 := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
+			addr2 := "localhost:" + strconv.Itoa(9000+rand.Intn(999))
+			rieInvokeAPI := "http://" + addr1 + "/2015-03-31/functions/function/invocations"
 			// run the runtime interface emulator, capture the logs for assertion
-			cmd := exec.Command("aws-lambda-rie", "sigterm.handler")
+			cmd := exec.Command("aws-lambda-rie", "--runtime-interface-emulator-address", addr1, "--runtime-api-address", addr2, "sigterm.handler")
 			cmd.Env = append([]string{
 				"PATH=" + testDir,
 				"AWS_LAMBDA_FUNCTION_TIMEOUT=2",

--- a/lambdaurl/http_handler.go
+++ b/lambdaurl/http_handler.go
@@ -130,7 +130,8 @@ func Wrap(handler http.Handler) func(context.Context, *events.LambdaFunctionURLR
 		}
 		go func() {
 			defer close(ready)
-			defer w.Close()                 // TODO: recover and CloseWithError the any panic value once the runtime API client supports plumbing fatal errors through the reader
+			defer w.Close() // TODO: recover and CloseWithError the any panic value once the runtime API client supports plumbing fatal errors through the reader
+			//nolint:errcheck
 			defer responseWriter.Write(nil) // force default status, headers, content type detection, if none occured during the execution of the handler
 			handler.ServeHTTP(responseWriter, httpRequest)
 		}()

--- a/lambdaurl/http_handler_test.go
+++ b/lambdaurl/http_handler_test.go
@@ -148,7 +148,7 @@ func TestWrap(t *testing.T) {
 		"detect content type: writes html": {
 			input: helloRequest,
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte("<!DOCTYPE HTML><html></html>"))
+				_, _ = w.Write([]byte("<!DOCTYPE HTML><html></html>"))
 			},
 			detectContentType: true,
 			expectBody:        "<!DOCTYPE HTML><html></html>",
@@ -160,7 +160,7 @@ func TestWrap(t *testing.T) {
 		"detect content type: writes zeros": {
 			input: helloRequest,
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte{0, 0, 0, 0, 0})
+				_, _ = w.Write([]byte{0, 0, 0, 0, 0})
 			},
 			detectContentType: true,
 			expectBody:        "\x00\x00\x00\x00\x00",

--- a/lambdaurl/http_handler_test.go
+++ b/lambdaurl/http_handler_test.go
@@ -12,10 +12,12 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -213,7 +215,8 @@ func TestRequestContext(t *testing.T) {
 }
 
 func TestStartViaEmulator(t *testing.T) {
-	rieInvokeAPI := "http://localhost:8080/2015-03-31/functions/function/invocations"
+	addr := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
+	rieInvokeAPI := "http://" + addr + "/2015-03-31/functions/function/invocations"
 	if _, err := exec.LookPath("aws-lambda-rie"); err != nil {
 		t.Skipf("%v - install from https://github.com/aws/aws-lambda-runtime-interface-emulator/", err)
 	}
@@ -226,7 +229,7 @@ func TestStartViaEmulator(t *testing.T) {
 	require.NoError(t, handlerBuild.Run())
 
 	// run the runtime interface emulator, capture the logs for assertion
-	cmd := exec.Command("aws-lambda-rie", "lambdaurl.handler")
+	cmd := exec.Command("aws-lambda-rie", "--runtime-interface-emulator-address", addr, "lambdaurl.handler")
 	cmd.Env = []string{
 		"PATH=" + testDir,
 		"AWS_LAMBDA_FUNCTION_TIMEOUT=2",

--- a/lambdaurl/http_handler_test.go
+++ b/lambdaurl/http_handler_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -215,8 +214,8 @@ func TestRequestContext(t *testing.T) {
 }
 
 func TestStartViaEmulator(t *testing.T) {
-	addr1 := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
-	addr2 := "localhost:" + strconv.Itoa(9000+rand.Intn(999))
+	addr1 := "localhost:" + strconv.Itoa(6001)
+	addr2 := "localhost:" + strconv.Itoa(7001)
 	rieInvokeAPI := "http://" + addr1 + "/2015-03-31/functions/function/invocations"
 	if _, err := exec.LookPath("aws-lambda-rie"); err != nil {
 		t.Skipf("%v - install from https://github.com/aws/aws-lambda-runtime-interface-emulator/", err)

--- a/lambdaurl/http_handler_test.go
+++ b/lambdaurl/http_handler_test.go
@@ -215,8 +215,9 @@ func TestRequestContext(t *testing.T) {
 }
 
 func TestStartViaEmulator(t *testing.T) {
-	addr := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
-	rieInvokeAPI := "http://" + addr + "/2015-03-31/functions/function/invocations"
+	addr1 := "localhost:" + strconv.Itoa(8000+rand.Intn(999))
+	addr2 := "localhost:" + strconv.Itoa(9000+rand.Intn(999))
+	rieInvokeAPI := "http://" + addr1 + "/2015-03-31/functions/function/invocations"
 	if _, err := exec.LookPath("aws-lambda-rie"); err != nil {
 		t.Skipf("%v - install from https://github.com/aws/aws-lambda-runtime-interface-emulator/", err)
 	}
@@ -229,7 +230,7 @@ func TestStartViaEmulator(t *testing.T) {
 	require.NoError(t, handlerBuild.Run())
 
 	// run the runtime interface emulator, capture the logs for assertion
-	cmd := exec.Command("aws-lambda-rie", "--runtime-interface-emulator-address", addr, "lambdaurl.handler")
+	cmd := exec.Command("aws-lambda-rie", "--runtime-interface-emulator-address", addr1, "--runtime-api-address", addr2, "lambdaurl.handler")
 	cmd.Env = []string{
 		"PATH=" + testDir,
 		"AWS_LAMBDA_FUNCTION_TIMEOUT=2",

--- a/lambdaurl/http_handler_test.go
+++ b/lambdaurl/http_handler_test.go
@@ -132,10 +132,19 @@ func TestWrap(t *testing.T) {
 			detectContentType: true,
 			expectStatus:      http.StatusAccepted,
 			expectHeaders: map[string]string{
-				"Content-Type": "text/plain; charset=utf-8",
+				"Content-Type": "application/octet-stream",
 			},
 		},
-
+		"detect content type: empty handler": {
+			input: helloRequest,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+			},
+			detectContentType: true,
+			expectStatus:      http.StatusOK,
+			expectHeaders: map[string]string{
+				"Content-Type": "application/octet-stream",
+			},
+		},
 		"detect content type: writes html": {
 			input: helloRequest,
 			handler: func(w http.ResponseWriter, r *http.Request) {

--- a/lambdaurl/testdata/lambdaurl.go
+++ b/lambdaurl/testdata/lambdaurl.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/lambdaurl"
+)
+
+const content = `<!DOCTYPE HTML>
+<html>
+<body>
+Hello World!
+</body>
+</html>
+`
+
+func main() {
+	lambdaurl.Start(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(w, strings.NewReader(content))
+	}),
+		lambdaurl.WithDetectContentType(true),
+	)
+}


### PR DESCRIPTION
*Issue #, if available:*

#508 

*Description of changes:*

Adds an option to utilize the stblib http.DetectContentType on the first `Write` to a lambda url response writer. This is done by adding a `lambda.WithContextValue` as a mechinisim to squirrel arbitrary context values in `StartWithOptions` wrappers like `lambdaurl.Start`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
