### PR TITLE
Added Deleted field to support codecommit ref delete events

### DIFF
--- a/events/code_commit.go
+++ b/events/code_commit.go
@@ -91,11 +91,12 @@ type CodeCommitReference struct {
 	Commit  string `json:"commit"`
 	Ref     string `json:"ref"`
 	Created bool   `json:"created,omitempty"`
+	Deleted bool   `json:"deleted,omitempty"`
 }
 
 // String returns a string representation of this object.
 // Useful for testing and debugging.
 func (r CodeCommitReference) String() string {
 	return fmt.Sprintf(
-		"{commit: %v, ref: %v, created: %v}", r.Commit, r.Ref, r.Created)
+		"{commit: %v, ref: %v, created: %v, deleted: %v}", r.Commit, r.Ref, r.Created, r.Deleted)
 }

--- a/events/code_commit_test.go
+++ b/events/code_commit_test.go
@@ -30,6 +30,16 @@ func TestCodeCommitReference(t *testing.T) {
         }
       `),
 		},
+		{
+			Name: "Deleted CodeCommitReference",
+			Input: []byte(`
+        {
+          "commit": "5c4ef1049f1d27deadbeeff313e0730018be182b",
+          "ref": "refs/heads/master",
+          "deleted": true
+        }
+      `),
+		},
 	}
 
 	for _, c := range cases {
@@ -62,7 +72,12 @@ func TestCodeCommitCodeCommit(t *testing.T) {
               "commit": "5c4ef1049f1d27deadbeeff313e0730018be182b",
               "ref": "refs/heads/master",
               "created": true
-            }
+            },
+			{
+			  "commit": "5c4ef1049f1d27deadbeeff313e0730018be182b",
+			  "ref": "refs/heads/master",
+			  "deleted": true
+        	}
           ]
         }
       `),


### PR DESCRIPTION
*Issue #, if available:*
#528 

*Description of changes:*
Added `Deleted` field so that the consumer is able to identify reference delete events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
