### PR TITLE
Add client certificate struct as field to APIGatewayRequestIdentity

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -133,19 +133,20 @@ type APIGatewayV2HTTPResponse struct {
 
 // APIGatewayRequestIdentity contains identity information for the request caller.
 type APIGatewayRequestIdentity struct {
-	CognitoIdentityPoolID         string `json:"cognitoIdentityPoolId,omitempty"`
-	AccountID                     string `json:"accountId,omitempty"`
-	CognitoIdentityID             string `json:"cognitoIdentityId,omitempty"`
-	Caller                        string `json:"caller,omitempty"`
-	APIKey                        string `json:"apiKey,omitempty"`
-	APIKeyID                      string `json:"apiKeyId,omitempty"`
-	AccessKey                     string `json:"accessKey,omitempty"`
-	SourceIP                      string `json:"sourceIp"`
-	CognitoAuthenticationType     string `json:"cognitoAuthenticationType,omitempty"`
-	CognitoAuthenticationProvider string `json:"cognitoAuthenticationProvider,omitempty"`
-	UserArn                       string `json:"userArn,omitempty"` //nolint: stylecheck
-	UserAgent                     string `json:"userAgent"`
-	User                          string `json:"user,omitempty"`
+	CognitoIdentityPoolID         string                                                          `json:"cognitoIdentityPoolId,omitempty"`
+	AccountID                     string                                                          `json:"accountId,omitempty"`
+	CognitoIdentityID             string                                                          `json:"cognitoIdentityId,omitempty"`
+	Caller                        string                                                          `json:"caller,omitempty"`
+	APIKey                        string                                                          `json:"apiKey,omitempty"`
+	APIKeyID                      string                                                          `json:"apiKeyId,omitempty"`
+	AccessKey                     string                                                          `json:"accessKey,omitempty"`
+	SourceIP                      string                                                          `json:"sourceIp"`
+	CognitoAuthenticationType     string                                                          `json:"cognitoAuthenticationType,omitempty"`
+	CognitoAuthenticationProvider string                                                          `json:"cognitoAuthenticationProvider,omitempty"`
+	UserArn                       string                                                          `json:"userArn,omitempty"` //nolint: stylecheck
+	UserAgent                     string                                                          `json:"userAgent"`
+	User                          string                                                          `json:"user,omitempty"`
+	ClientCert                    *APIGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert `json:"clientCert,omitempty"`
 }
 
 // APIGatewayWebsocketProxyRequest contains data coming from the API Gateway proxy

--- a/events/apigw_test.go
+++ b/events/apigw_test.go
@@ -33,6 +33,16 @@ func TestApiGatewayRequestMarshaling(t *testing.T) {
 		t.Errorf("could not extract authorizer context: %v", authContext)
 	}
 
+	clientCert := inputEvent.RequestContext.Identity.ClientCert
+	if clientCert.ClientCertPem != "CERT_CONTENT" ||
+		clientCert.SubjectDN != "www.example.com" ||
+		clientCert.IssuerDN != "Example issuer" ||
+		clientCert.SerialNumber != "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1" ||
+		clientCert.Validity.NotBefore != "May 28 12:30:02 2019 GMT" ||
+		clientCert.Validity.NotAfter != "Aug  5 09:36:04 2021 GMT" {
+		t.Errorf("could not extract client certificate content: %v", clientCert)
+	}
+
 	// serialize to json
 	outputJSON, err := json.Marshal(inputEvent)
 	if err != nil {

--- a/events/testdata/apigw-request.json
+++ b/events/testdata/apigw-request.json
@@ -79,7 +79,17 @@
 			"cognitoAuthenticationProvider": "theCognitoAuthenticationProvider",
 			"userArn": "theUserArn",
 			"userAgent": "PostmanRuntime/2.4.5",
-			"user": "theUser"
+			"user": "theUser",
+			"clientCert": {
+				"clientCertPem": "CERT_CONTENT",
+				"subjectDN": "www.example.com",
+				"issuerDN": "Example issuer",
+				"serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+				"validity": {
+					"notBefore": "May 28 12:30:02 2019 GMT",
+					"notAfter": "Aug  5 09:36:04 2021 GMT"
+				}
+			}
 		},
 		"authorizer": {
 			"principalId": "admin",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

API Gateway proxy request should have a client cert field under the requestContext.identity field. This can be seen in the docs https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html. Had to use a pointer and omitempty otherwise unmarshaling and then marshaling results in a client cert field being populated with zero values. Updated test data to include sample data from the docs and also updated test case to verify those values are present after unmarshaling.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
