### PR TITLE
feat: support of otf metadata for iceberg destinations

### DIFF
--- a/events/firehose.go
+++ b/events/firehose.go
@@ -37,7 +37,14 @@ type KinesisFirehoseResponseRecord struct {
 }
 
 type KinesisFirehoseResponseRecordMetadata struct {
-	PartitionKeys map[string]string `json:"partitionKeys"`
+	PartitionKeys map[string]string                                `json:"partitionKeys"`
+	OtfMetadata   KinesisFirehoseResponseRecordMetadataOtfMetadata `json:"otfMetadata"`
+}
+
+type KinesisFirehoseResponseRecordMetadataOtfMetadata struct {
+	DestinationDatabaseName string `json:"destinationDatabaseName"`
+	DestinationTableName    string `json:"destinationTableName"`
+	Operation               string `json:"operation"`
 }
 
 type KinesisFirehoseRecordMetadata struct {


### PR DESCRIPTION
# What?
Add support of `otfMetadata` when using Iceberg as destionations for Firehose.

# Why?
Firehose can route incoming records in a stream to different Iceberg tables based on the content of the record.   
Also it is possible to provide a `operation` attribute which will indicate to Iceberg if the record should be treated as an `insert`, `update` or `delete` operation.  
See https://docs.aws.amazon.com/firehose/latest/dev/apache-iceberg-format-input-record-different.html#apache-iceberg-route-lambda


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
