### PR TITLE
Support otfMetadata in Kinesis firehose response metadata for iceberg table routing

### DIFF
--- a/events/firehose.go
+++ b/events/firehose.go
@@ -37,7 +37,14 @@ type KinesisFirehoseResponseRecord struct {
 }
 
 type KinesisFirehoseResponseRecordMetadata struct {
-	PartitionKeys map[string]string `json:"partitionKeys"`
+	PartitionKeys map[string]string                  `json:"partitionKeys"`
+	OTFMetadata   KinesisFirehoseResponseOTFMetadata `json:"otfMetadata"`
+}
+
+type KinesisFirehoseResponseOTFMetadata struct {
+	DestinationTableName    string `json:"destinationTableName"`
+	DestinationDatabaseName string `json:"destinationDatabaseName"`
+	Operation               string `json:"operation"`
 }
 
 type KinesisFirehoseRecordMetadata struct {

--- a/events/testdata/kinesis-firehose-response.json
+++ b/events/testdata/kinesis-firehose-response.json
@@ -5,7 +5,12 @@
        "recordId": "record1",
        "result": "TRANSFORMED_STATE_OK",
        "metadata": {
-         "partitionKeys": {}
+         "partitionKeys": {},
+         "otfMetadata": {
+           "destinationTableName": "",
+           "destinationDatabaseName": "",
+           "operation": ""
+         }
        }
      },
      {
@@ -13,7 +18,12 @@
        "recordId": "record2",
        "result": "TRANSFORMED_STATE_DROPPED",
        "metadata": {
-         "partitionKeys": {}
+         "partitionKeys": {},
+         "otfMetadata": {
+           "destinationTableName": "",
+           "destinationDatabaseName": "",
+           "operation": ""
+         }
        }
      },
      {
@@ -24,6 +34,11 @@
          "partitionKeys": {
            "iamKey1": "iamValue1",
            "iamKey2": "iamValue2"
+         },
+         "otfMetadata": {
+           "destinationTableName": "",
+           "destinationDatabaseName": "",
+           "operation": ""
          }
        }
      }


### PR DESCRIPTION
Issue: https://github.com/aws/aws-lambda-go/issues/575

Add otfMetadata in metadata for firehose kinesis response record to support table routing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
