### PR TITLE
Add Cc to common headers

### DIFF
--- a/events/ses.go
+++ b/events/ses.go
@@ -49,6 +49,7 @@ type SimpleEmailHeader struct {
 type SimpleEmailCommonHeaders struct {
 	From       []string `json:"from"`
 	To         []string `json:"to"`
+	Cc         []string `json:"cc,omitempty"`
 	ReturnPath string   `json:"returnPath"`
 	MessageID  string   `json:"messageId"`
 	Date       string   `json:"date"`

--- a/events/testdata/ses-sns-event.json
+++ b/events/testdata/ses-sns-event.json
@@ -101,6 +101,10 @@
             "to": [
               "recipient@example.com"
             ],
+            "cc": [
+              "cc@example.com",
+              "cc2@example.com"
+            ],
             "messageId": "<61967230-7A45-4A9D-BEC9-87CBCF2211C9@example.com>",
             "subject": "Example subject"
           }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During development, I confirmed that the commonHeders of the event sent from the ses included the Cc. However, I added it because I felt uncomfortable because there was no field in that structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
