### PR TITLE
chore(dep): update testify to v1.10.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - name: golangci-golint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,6 @@ jobs:
           - "1.19"
           - "1.18"
           - "1.17"
-          - "1.16"
-          - "1.15"
-          - "1.14"
-          - "1.13"
-
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v3
@@ -80,4 +75,3 @@ jobs:
           env_vars: GO
         env:
           GO: ${{ matrix.go }}
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Go Dep
 vendor
+
+# ignore golangci-lint binary if running locally
+bin/golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-lambda-go
 
 go 1.18
 
-require github.com/stretchr/testify v1.7.2
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/lambda/rpc_function_test.go
+++ b/lambda/rpc_function_test.go
@@ -64,7 +64,9 @@ func TestInvoke(t *testing.T) {
 }
 
 func TestInvokeWithContext(t *testing.T) {
-	key := struct{}{}
+	// dummyKey creates a safe context to appease the linter
+	type dummyKey struct{}
+	var key dummyKey
 	srv := NewFunction(&handlerOptions{
 		handlerFunc: func(ctx context.Context, _ []byte) (io.Reader, error) {
 			assert.Equal(t, "dummy", ctx.Value(key))


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
This started as a small PR to update `testify` to v1.10.0, but it ended up requiring a few additional changes to make the linter and test runner happy.

- REMOVED `v1.13`, `v1.14`, `v1.15`, and `v1.16` from the test runner matrix; these are no longer supported with the current version of `testify.` This should not be a problem with future-forward releases, since these are VERY OLD versions of go.
- UPDATED go.sum using `go mod tidy` to clean up old dependencies, such as `github.com/stretchr/objx` that are no longer needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
