### PR TITLE
Deprecate Cognito PreTokenGenV2 and introduce PreTokenGenV2_0

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -54,10 +54,21 @@ type CognitoEventUserPoolsPreTokenGen struct {
 
 // CognitoEventUserPoolsPreTokenGenV2 is sent by Amazon Cognito User Pools when a user attempts to retrieve
 // credentials, allowing a Lambda to perform insert, suppress or override claims and scopes
+//
+// Deprecated: Use CognitoEventUserPoolsPreTokenGenV2_0 instead.
+// This struct incorrectly restricts the ClaimsToAddOrOverride values as strings, but Cogntio supports any type.
 type CognitoEventUserPoolsPreTokenGenV2 struct {
 	CognitoEventUserPoolsHeader
 	Request  CognitoEventUserPoolsPreTokenGenV2Request  `json:"request"`
 	Response CognitoEventUserPoolsPreTokenGenV2Response `json:"response"`
+}
+
+// CognitoEventUserPoolsPreTokenGenV2_0 is sent by Amazon Cognito User Pools when a user attempts to retrieve
+// credentials, allowing a Lambda to perform insert, suppress or override claims and scopes
+type CognitoEventUserPoolsPreTokenGenV2_0 struct {
+	CognitoEventUserPoolsHeader
+	Request  CognitoEventUserPoolsPreTokenGenRequestV2_0  `json:"request"`
+	Response CognitoEventUserPoolsPreTokenGenResponseV2_0 `json:"response"`
 }
 
 // CognitoEventUserPoolsPostAuthentication is sent by Amazon Cognito User Pools after a user is authenticated,
@@ -134,11 +145,21 @@ type CognitoEventUserPoolsPreTokenGenRequest struct {
 }
 
 // CognitoEventUserPoolsPreTokenGenV2Request contains request portion of V2 PreTokenGen event
+//
+// Deprecated: Use CognitoEventUserPoolsPreTokenGenRequestV2_0 instead
 type CognitoEventUserPoolsPreTokenGenV2Request struct {
 	UserAttributes     map[string]string  `json:"userAttributes"`
 	GroupConfiguration GroupConfiguration `json:"groupConfiguration"`
 	ClientMetadata     map[string]string  `json:"clientMetadata,omitempty"`
 	Scopes             []string           `json:"scopes"`
+}
+
+// CognitoEventUserPoolsPreTokenGenRequestV2_0 contains request portion of V2 PreTokenGen event
+type CognitoEventUserPoolsPreTokenGenRequestV2_0 struct {
+	UserAttributes     map[string]string      `json:"userAttributes"`
+	GroupConfiguration GroupConfigurationV2_0 `json:"groupConfiguration"`
+	ClientMetadata     map[string]string      `json:"clientMetadata,omitempty"`
+	Scopes             []string               `json:"scopes"`
 }
 
 // CognitoEventUserPoolsPreTokenGenResponse contains the response portion of a PreTokenGen event
@@ -147,8 +168,15 @@ type CognitoEventUserPoolsPreTokenGenResponse struct {
 }
 
 // CognitoEventUserPoolsPreTokenGenV2Response contains the response portion of a V2 PreTokenGen event
+//
+// Deprecated: Use CognitoEventUserPoolsPreTokenGenResponseV2_0 instead
 type CognitoEventUserPoolsPreTokenGenV2Response struct {
 	ClaimsAndScopeOverrideDetails ClaimsAndScopeOverrideDetails `json:"claimsAndScopeOverrideDetails"`
+}
+
+// CognitoEventUserPoolsPreTokenGenResponseV2_0 contains the response portion of a V2 PreTokenGen event
+type CognitoEventUserPoolsPreTokenGenResponseV2_0 struct {
+	ClaimsAndScopeOverrideDetails ClaimsAndScopeOverrideDetailsV2_0 `json:"claimsAndScopeOverrideDetails"`
 }
 
 // CognitoEventUserPoolsPostAuthenticationRequest contains the request portion of a PostAuthentication event
@@ -179,10 +207,19 @@ type CognitoEventUserPoolsMigrateUserResponse struct {
 }
 
 // ClaimsAndScopeOverrideDetails allows lambda to add, suppress or override V2 claims and scopes in the token
+//
+// Deprecated: Use ClaimsAndScopeOverrideDetailsV2_0 instead
 type ClaimsAndScopeOverrideDetails struct {
 	IDTokenGeneration     IDTokenGeneration     `json:"idTokenGeneration"`
 	AccessTokenGeneration AccessTokenGeneration `json:"accessTokenGeneration"`
 	GroupOverrideDetails  GroupConfiguration    `json:"groupOverrideDetails"`
+}
+
+// ClaimsAndScopeOverrideDetailsV2 allows lambda to add, suppress or override V2 claims and scopes in the token
+type ClaimsAndScopeOverrideDetailsV2_0 struct {
+	IDTokenGeneration     IDTokenGenerationV2_0     `json:"idTokenGeneration"`
+	AccessTokenGeneration AccessTokenGenerationV2_0 `json:"accessTokenGeneration"`
+	GroupOverrideDetails  GroupConfigurationV2_0    `json:"groupOverrideDetails"`
 }
 
 // IDTokenGeneration allows lambda to modify the ID token
@@ -191,12 +228,28 @@ type IDTokenGeneration struct {
 	ClaimsToSuppress      []string          `json:"claimsToSuppress"`
 }
 
+// IDTokenGenerationV2_0 allows lambda to modify the ID token
+type IDTokenGenerationV2_0 struct {
+	ClaimsToAddOrOverride map[string]interface{} `json:"claimsToAddOrOverride"`
+	ClaimsToSuppress      []string               `json:"claimsToSuppress"`
+}
+
 // AccessTokenGeneration allows lambda to modify the access token
+//
+// Deprecated: Use AccessTokenGenerationV2_0 instead
 type AccessTokenGeneration struct {
 	ClaimsToAddOrOverride map[string]string `json:"claimsToAddOrOverride"`
 	ClaimsToSuppress      []string          `json:"claimsToSuppress"`
 	ScopesToAdd           []string          `json:"scopesToAdd"`
 	ScopesToSuppress      []string          `json:"scopesToSuppress"`
+}
+
+// AccessTokenGenerationV2_0 allows lambda to modify the access token
+type AccessTokenGenerationV2_0 struct {
+	ClaimsToAddOrOverride map[string]interface{} `json:"claimsToAddOrOverride"`
+	ClaimsToSuppress      []string               `json:"claimsToSuppress"`
+	ScopesToAdd           []string               `json:"scopesToAdd"`
+	ScopesToSuppress      []string               `json:"scopesToSuppress"`
 }
 
 // ClaimsOverrideDetails allows lambda to add, suppress or override claims in the token
@@ -208,6 +261,13 @@ type ClaimsOverrideDetails struct {
 
 // GroupConfiguration allows lambda to override groups, roles and set a preferred role
 type GroupConfiguration struct {
+	GroupsToOverride   []string `json:"groupsToOverride"`
+	IAMRolesToOverride []string `json:"iamRolesToOverride"`
+	PreferredRole      *string  `json:"preferredRole"`
+}
+
+// GroupConfigurationV2_0 allows lambda to override groups, roles and set a preferred role
+type GroupConfigurationV2_0 struct {
 	GroupsToOverride   []string `json:"groupsToOverride"`
 	IAMRolesToOverride []string `json:"iamRolesToOverride"`
 	PreferredRole      *string  `json:"preferredRole"`

--- a/events/cognito_test.go
+++ b/events/cognito_test.go
@@ -162,6 +162,28 @@ func TestCognitoEventUserPoolsPreTokenGenV2Marshaling(t *testing.T) {
 	test.AssertJsonsEqual(t, inputJSON, outputJSON)
 }
 
+func TestCognitoEventUserPoolsPreTokenGenV2_0Marshaling(t *testing.T) {
+	// read json from file
+	inputJSON, err := ioutil.ReadFile("./testdata/cognito-event-userpools-pretokengen-v2_0.json")
+	if err != nil {
+		t.Errorf("could not open test file. details: %v", err)
+	}
+
+	// de-serialize into CognitoEvent
+	var inputEvent CognitoEventUserPoolsPreTokenGenV2_0
+	if err := json.Unmarshal(inputJSON, &inputEvent); err != nil {
+		t.Errorf("could not unmarshal event. details: %v", err)
+	}
+
+	// serialize to json
+	outputJSON, err := json.Marshal(inputEvent)
+	if err != nil {
+		t.Errorf("could not marshal event. details: %v", err)
+	}
+
+	test.AssertJsonsEqual(t, inputJSON, outputJSON)
+}
+
 func TestCognitoEventUserPoolsDefineAuthChallengeMarshaling(t *testing.T) {
 	var inputEvent CognitoEventUserPoolsDefineAuthChallenge
 	test.AssertJsonFile(t, "./testdata/cognito-event-userpools-define-auth-challenge.json", &inputEvent)

--- a/events/testdata/cognito-event-userpools-pretokengen-v2_0.json
+++ b/events/testdata/cognito-event-userpools-pretokengen-v2_0.json
@@ -1,0 +1,73 @@
+{
+  "version": "2",
+  "triggerSource": "TokenGeneration_Authentication",
+  "region": "us-east-1",
+  "userPoolId": "us-east-1_EXAMPLE",
+  "userName": "testuser",
+  "callerContext": {
+    "awsSdkVersion": "aws-sdk-unknown-unknown",
+    "clientId": "1example23456789"
+  },
+  "request": {
+    "userAttributes": {
+      "sub": "a36036a8-9061-424d-a737-56d57dae7bc6",
+      "cognito:email_alias": "testuser@example.com",
+      "cognito:user_status": "CONFIRMED",
+      "email_verified": "true",
+      "email": "testuser@example.com"
+    },
+    "groupConfiguration": {
+      "groupsToOverride": [],
+      "iamRolesToOverride": [],
+      "preferredRole": null
+    },
+    "scopes": [
+      "aws.cognito.signin.user.admin"
+    ]
+  },
+  "response": {
+    "claimsAndScopeOverrideDetails": {
+      "idTokenGeneration": {
+        "claimsToAddOrOverride": {
+          "family_name": "xyz",
+          "favorite_number": 2
+        },
+        "claimsToSuppress": [
+          "email",
+          "birthdate"
+        ]
+      },
+      "accessTokenGeneration": {
+        "claimsToAddOrOverride": {
+          "family_name": "xyz",
+          "favorite_number": 2
+        },
+        "claimsToSuppress": [
+          "email",
+          "birthdate"
+        ],
+        "scopesToAdd": [
+          "scope1",
+          "scope2",
+          "scopeLomond"
+        ],
+        "scopesToSuppress": [
+          "phone_number"
+        ]
+      },
+      "groupOverrideDetails": {
+        "groupsToOverride": [
+          "group-A",
+          "group-B",
+          "group-C"
+        ],
+        "iamRolesToOverride": [
+          "arn:aws:iam::123456789012:role/sns_callerA",
+          "arn:aws:iam::123456789012:role/sns_callerB",
+          "arn:aws:iam::123456789012:role/sns_callerC"
+        ],
+        "preferredRole": "arn:aws:iam::123456789012:role/sns_caller"
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

#584 
#585 

*Description of changes:*

This inner `AccessTokenGeneration` and `IDTokenGeneration` structs used in the PreTokenGenV2 event struct incorrectly restricts the `ClaimsToAddOrOverride` map values as strings, but Cognito supports any type when the trigger is configured for V2 or V3. 

Correcting the structs in-place would:
1. be a breaking change depending on how the fields are read-to/written-from in end user code
2. mislead V1 users, where Cognito only supports string values in the map

So I copied all existing structs related to Cognito's PreTokenGen V2_0 request/response, and suffixed the copies with `V2_0` - took this convention from the current version of the documentation, which includes paragraphs like:

> Because Amazon Cognito invokes this trigger before token generation, you can customize the claims in user pool tokens. With the Basic features of the version one or V1_0 pre token generation trigger event, you can customize the identity (ID) token. In user pools with the Essentials or Plus feature plan, you can generate the version two or V2_0 trigger event with access token customization, and the version three or V3_0 trigger event with access token customization for machine-to-machine (M2M) client-credentials grants.

So seemed appropriate to take that convention rather than coming up with an alternative way to 'V2' the existing 'V2' struct.

While the PreTokenGenV2 still works, I also added a `// Deprecated:` annotation to alert end users via their editors/linters that they may be missing out on some features.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
