### PR TITLE
Remove _X_AMZN_TRACE_ID environment variable mutations when handling concurrent invokes

### DIFF
--- a/lambda/invoke_loop.go
+++ b/lambda/invoke_loop.go
@@ -64,7 +64,9 @@ func handleInvoke(invoke *invoke, handler *handlerOptions) error {
 
 	// set the trace id
 	traceID := invoke.headers.Get(headerTraceID)
-	os.Setenv("_X_AMZN_TRACE_ID", traceID)
+	if lambdacontext.MaxConcurrency() == 1 {
+		os.Setenv("_X_AMZN_TRACE_ID", traceID)
+	}
 	// nolint:staticcheck
 	ctx = context.WithValue(ctx, "x-amzn-trace-id", traceID)
 


### PR DESCRIPTION
*Description of changes:*

Small followup to https://github.com/aws/aws-lambda-go/pull/600, mutating this environment variable doesn't make sense with concurrent invokes. Correct place to get the trace id has always been through the `lambdacontext`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
