### PR TITLE
fix flaky test TestRuntimeAPILoopWithConcurrency

### DIFF
--- a/lambda/invoke_loop_gte_go122_test.go
+++ b/lambda/invoke_loop_gte_go122_test.go
@@ -65,8 +65,10 @@ func TestRuntimeAPILoopWithConcurrency(t *testing.T) {
 	endpoint := strings.Split(ts.URL, "://")[1]
 	expectedError := fmt.Sprintf("failed to GET http://%s/2018-06-01/runtime/invocation/next: got unexpected status code: 410", endpoint)
 	assert.EqualError(t, startRuntimeAPILoopWithConcurrency(endpoint, handler, concurrency), expectedError)
+	record.lock.Lock()
 	assert.GreaterOrEqual(t, record.nGets, nInvokes+1)
 	assert.Equal(t, nInvokes, record.nPosts)
+	record.lock.Unlock()
 	assert.Equal(t, int32(concurrency), maxActive.Load())
 	responses := make(map[string]int)
 	for _, response := range record.responses {

--- a/lambda/invoke_loop_test.go
+++ b/lambda/invoke_loop_test.go
@@ -448,14 +448,6 @@ func runtimeAPIServer(eventPayload string, failAfter int, overrides ...eventMeta
 	record := &requestRecord{}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-ctx.Done():
-			w.WriteHeader(http.StatusGone)
-			_, _ = w.Write([]byte("END THE TEST!"))
-			return
-		default:
-		}
-
 		switch r.Method {
 		case http.MethodGet:
 			numInvokesRequestedLock.Lock()


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The `TestRuntimeAPILoopWithConcurrency` fails occasionally.

```plain
$ go test -timeout 30s -run ^TestRuntimeAPILoopWithConcurrency$ github.com/aws/aws-lambda-go/lambda -v -count 100
(...snip..)
=== RUN   TestRuntimeAPILoopWithConcurrency
2025/12/11 10:27:50 {"errorMessage":"error-request-7","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-6","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-16","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-17","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-26","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-27","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-36","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-37","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-47","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-46","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-57","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-56","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-66","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-67","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-76","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-77","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-86","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-96","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-87","errorType":"errorString"}
2025/12/11 10:27:50 {"errorMessage":"error-request-97","errorType":"errorString"}
    invoke_loop_gte_go122_test.go:69:
        	Error Trace:	invoke_loop_gte_go122_test.go:69
        	Error:      	Not equal:
        	            	expected: 100
        	            	actual  : 99
        	Test:       	TestRuntimeAPILoopWithConcurrency
    invoke_loop_gte_go122_test.go:75:
        	Error Trace:	invoke_loop_gte_go122_test.go:75
        	Error:      	"map["request-0":%!s(int=1) "request-1":%!s(int=1) "request-10":%!s(int=1) "request-11":%!s(int=1) "request-12":%!s(int=1) "request-13":%!s(int=1) "request-14":%!s(int=1) "request-15":%!s(int=1) "request-18":%!s(int=1) "request-19":%!s(int=1) "request-2":%!s(int=1) "request-20":%!s(int=1) "request-21":%!s(int=1) "request-22":%!s(int=1) "request-23":%!s(int=1) "request-24":%!s(int=1) "request-25":%!s(int=1) "request-28":%!s(int=1) "request-29":%!s(int=1) "request-3":%!s(int=1) "request-30":%!s(int=1) "request-31":%!s(int=1) "request-32":%!s(int=1) "request-33":%!s(int=1) "request-34":%!s(int=1) "request-35":%!s(int=1) "request-38":%!s(int=1) "request-39":%!s(int=1) "request-4":%!s(int=1) "request-40":%!s(int=1) "request-41":%!s(int=1) "request-42":%!s(int=1) "request-43":%!s(int=1) "request-44":%!s(int=1) "request-45":%!s(int=1) "request-48":%!s(int=1) "request-49":%!s(int=1) "request-5":%!s(int=1) "request-50":%!s(int=1) "request-51":%!s(int=1) "request-52":%!s(int=1) "request-53":%!s(int=1) "request-54":%!s(int=1) "request-55":%!s(int=1) "request-58":%!s(int=1) "request-59":%!s(int=1) "request-60":%!s(int=1) "request-61":%!s(int=1) "request-62":%!s(int=1) "request-63":%!s(int=1) "request-64":%!s(int=1) "request-65":%!s(int=1) "request-68":%!s(int=1) "request-69":%!s(int=1) "request-70":%!s(int=1) "request-71":%!s(int=1) "request-72":%!s(int=1) "request-73":%!s(int=1) "request-74":%!s(int=1) "request-75":%!s(int=1) "request-78":%!s(int=1) "request-79":%!s(int=1) "request-8":%!s(int=1) "request-80":%!s(int=1) "request-81":%!s(int=1) "request-82":%!s(int=1) "request-83":%!s(int=1) "request-84":%!s(int=1) "request-85":%!s(int=1) "request-88":%!s(int=1) "request-89":%!s(int=1) "request-9":%!s(int=1) "request-90":%!s(int=1) "request-91":%!s(int=1) "request-92":%!s(int=1) "request-93":%!s(int=1) "request-94":%!s(int=1) "request-95":%!s(int=1) "request-98":%!s(int=1) {"errorMessage":"error-request-16","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-17","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-26","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-27","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-36","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-37","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-46","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-47","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-56","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-57","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-6","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-66","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-67","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-7","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-76","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-77","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-86","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-87","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-96","errorType":"errorString"}:%!s(int=1) {"errorMessage":"error-request-97","errorType":"errorString"}:%!s(int=1)]" should have 100 item(s), but has 99
        	Test:       	TestRuntimeAPILoopWithConcurrency
    invoke_loop_gte_go122_test.go:84:
        	Error Trace:	invoke_loop_gte_go122_test.go:84
        	Error:      	map[string]int{"\"request-0\"":1, "\"request-1\"":1, "\"request-10\"":1, "\"request-11\"":1, "\"request-12\"":1, "\"request-13\"":1, "\"request-14\"":1, "\"request-15\"":1, "\"request-18\"":1, "\"request-19\"":1, "\"request-2\"":1, "\"request-20\"":1, "\"request-21\"":1, "\"request-22\"":1, "\"request-23\"":1, "\"request-24\"":1, "\"request-25\"":1, "\"request-28\"":1, "\"request-29\"":1, "\"request-3\"":1, "\"request-30\"":1, "\"request-31\"":1, "\"request-32\"":1, "\"request-33\"":1, "\"request-34\"":1, "\"request-35\"":1, "\"request-38\"":1, "\"request-39\"":1, "\"request-4\"":1, "\"request-40\"":1, "\"request-41\"":1, "\"request-42\"":1, "\"request-43\"":1, "\"request-44\"":1, "\"request-45\"":1, "\"request-48\"":1, "\"request-49\"":1, "\"request-5\"":1, "\"request-50\"":1, "\"request-51\"":1, "\"request-52\"":1, "\"request-53\"":1, "\"request-54\"":1, "\"request-55\"":1, "\"request-58\"":1, "\"request-59\"":1, "\"request-60\"":1, "\"request-61\"":1, "\"request-62\"":1, "\"request-63\"":1, "\"request-64\"":1, "\"request-65\"":1, "\"request-68\"":1, "\"request-69\"":1, "\"request-70\"":1, "\"request-71\"":1, "\"request-72\"":1, "\"request-73\"":1, "\"request-74\"":1, "\"request-75\"":1, "\"request-78\"":1, "\"request-79\"":1, "\"request-8\"":1, "\"request-80\"":1, "\"request-81\"":1, "\"request-82\"":1, "\"request-83\"":1, "\"request-84\"":1, "\"request-85\"":1, "\"request-88\"":1, "\"request-89\"":1, "\"request-9\"":1, "\"request-90\"":1, "\"request-91\"":1, "\"request-92\"":1, "\"request-93\"":1, "\"request-94\"":1, "\"request-95\"":1, "\"request-98\"":1, "{\"errorMessage\":\"error-request-16\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-17\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-26\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-27\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-36\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-37\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-46\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-47\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-56\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-57\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-6\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-66\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-67\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-7\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-76\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-77\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-86\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-87\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-96\",\"errorType\":\"errorString\"}":1, "{\"errorMessage\":\"error-request-97\",\"errorType\":\"errorString\"}":1} does not contain "\"request-99\""
        	Test:       	TestRuntimeAPILoopWithConcurrency
--- FAIL: TestRuntimeAPILoopWithConcurrency (0.22s)
(...snip..)
--- PASS: TestRuntimeAPILoopWithConcurrency (0.27s)
FAIL
FAIL	github.com/aws/aws-lambda-go/lambda	23.937s
FAIL
```

It is because the "END THE TEST!" signal is canceling out the normal GET request.
I've made it so that the "END THE TEST!" signal is sent only after other requests have finished successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
