### PR TITLE
Update AppSync Lambda authorisation request/response schema

### DIFF
--- a/events/appsync.go
+++ b/events/appsync.go
@@ -45,6 +45,7 @@ const (
 type AppSyncLambdaAuthorizerRequest struct {
 	AuthorizationToken string                                `json:"authorizationToken"`
 	RequestContext     AppSyncLambdaAuthorizerRequestContext `json:"requestContext"`
+	RequestHeaders     map[string]string                     `json:"requestHeaders"`
 }
 
 // AppSyncLambdaAuthorizerRequestContext contains the parameters of the AppSync invocation which triggered
@@ -61,6 +62,7 @@ type AppSyncLambdaAuthorizerRequestContext struct {
 // AppSyncLambdaAuthorizerResponse represents the expected format of an authorization response to AppSync.
 type AppSyncLambdaAuthorizerResponse struct {
 	IsAuthorized    bool                   `json:"isAuthorized"`
+	HandlerContext  map[string]string      `json:"handlerContext,omitempty"`
 	ResolverContext map[string]interface{} `json:"resolverContext,omitempty"`
 	DeniedFields    []string               `json:"deniedFields,omitempty"`
 	TTLOverride     *int                   `json:"ttlOverride,omitempty"`

--- a/events/testdata/appsync-lambda-auth-request.json
+++ b/events/testdata/appsync-lambda-auth-request.json
@@ -7,5 +7,8 @@
         "queryString": "mutation CreateEvent {...}\n\nquery MyQuery {...}\n",
         "operationName": "MyQuery",
         "variables": {}
+    },
+    "requestHeaders": {
+        "header": "value"
     }
 }

--- a/events/testdata/appsync-lambda-auth-response.json
+++ b/events/testdata/appsync-lambda-auth-response.json
@@ -1,5 +1,9 @@
 {
     "isAuthorized": true,
+    "handlerContext": {
+        "banana": "very yellow",
+        "apple": "very green"
+    },
     "resolverContext": {
         "banana": "very yellow",
         "apple": "very green"


### PR DESCRIPTION
See
https://docs.aws.amazon.com/appsync/latest/eventapi/configure-event-api-auth.html#aws-lambda-authorization for documentation on the `requestHeaders` on incoming request and `handlerContext` on the response.


*Description of changes:*
The `handlerContext` is identical to `resolverContext`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
