### PR TITLE
Add missing userNotFound field to Cognito auth trigger requests

### DIFF
--- a/events/cognito.go
+++ b/events/cognito.go
@@ -121,6 +121,7 @@ type CognitoEventUserPoolsPreSignupResponse struct {
 type CognitoEventUserPoolsPreAuthenticationRequest struct {
 	UserAttributes map[string]string `json:"userAttributes"`
 	ValidationData map[string]string `json:"validationData"`
+	UserNotFound   bool              `json:"userNotFound"`
 }
 
 // CognitoEventUserPoolsPreAuthenticationResponse contains the response portion of a PreAuthentication event
@@ -309,6 +310,7 @@ type CognitoEventUserPoolsCreateAuthChallengeRequest struct {
 	ChallengeName  string                                  `json:"challengeName"`
 	Session        []*CognitoEventUserPoolsChallengeResult `json:"session"`
 	ClientMetadata map[string]string                       `json:"clientMetadata"`
+	UserNotFound   bool                                    `json:"userNotFound"`
 }
 
 // CognitoEventUserPoolsCreateAuthChallengeResponse defines create auth challenge response rarameters
@@ -331,6 +333,7 @@ type CognitoEventUserPoolsVerifyAuthChallengeRequest struct {
 	PrivateChallengeParameters map[string]string `json:"privateChallengeParameters"`
 	ChallengeAnswer            interface{}       `json:"challengeAnswer"`
 	ClientMetadata             map[string]string `json:"clientMetadata"`
+	UserNotFound               bool              `json:"userNotFound"`
 }
 
 // CognitoEventUserPoolsVerifyAuthChallengeResponse defines verify auth challenge response parameters

--- a/events/testdata/cognito-event-userpools-create-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-create-auth-challenge.json
@@ -26,7 +26,8 @@
     ],
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
-    }
+    },
+    "userNotFound": false
   },
   "response": {
     "publicChallengeParameters": {

--- a/events/testdata/cognito-event-userpools-preauthentication.json
+++ b/events/testdata/cognito-event-userpools-preauthentication.json
@@ -15,7 +15,8 @@
       "validationData": {
           "k1": "v1",
           "k2": "v2"
-       }
+       },
+      "userNotFound": false
   },
   "response": {}
 }

--- a/events/testdata/cognito-event-userpools-verify-auth-challenge.json
+++ b/events/testdata/cognito-event-userpools-verify-auth-challenge.json
@@ -22,7 +22,8 @@
     "challengeAnswer": "123xxxx",
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
-    }
+    },
+    "userNotFound": false
   },
   "response": {
     "answerCorrect": true


### PR DESCRIPTION
*Issue #629*

*Description of changes:*
Add the `userNotFound` boolean field to three Cognito Lambda trigger request: `CognitoEventUserPoolsPreAuthenticationRequest`

It is also missing in:
  - `CognitoEventUserPoolsCreateAuthChallengeRequest`
  - `CognitoEventUserPoolsVerifyAuthChallengeRequest`
and now added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## References
Doc: `user pool lambda... - 
  - [pre-authentication](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-authentication.html#cognito-user-pools-lambda-trigger-syntax-pre-auth)
  - [create-auth-challenge](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html#cognito-user-pools-lambda-trigger-syntax-create-auth-challenge)
  - [verify-auth-challenge-response](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html#cognito-user-pools-lambda-trigger-syntax-verify-auth-challenge)